### PR TITLE
feat(transactions): add transaction model with schema and immutability constraints

### DIFF
--- a/server/src/features/transactions/transaction.model.js
+++ b/server/src/features/transactions/transaction.model.js
@@ -1,0 +1,82 @@
+import mongoose from "mongoose";
+
+const transactionSchema = new mongoose.Schema(
+  {
+    userId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "User",
+      required: true,
+    },
+
+    type: {
+      type: String,
+      required: true,
+      enum: ["payment", "refund", "wallet_top_up"],
+    },
+
+    amount: {
+      type: Number,
+      required: true,
+      min: 0,
+    },
+
+    status: {
+      type: String,
+      required: true,
+      enum: ["pending", "completed", "failed"],
+      default: "pending",
+    },
+
+    paymentMethod: {
+      type: String,
+      enum: ["credit_card", "wallet"],
+    },
+
+    description: {
+      type: String,
+      trim: true,
+    },
+
+    relatedEntity: {
+      type: {
+        type: String,
+      },
+      id: {
+        type: mongoose.Schema.Types.ObjectId,
+      },
+    },
+
+    stripePaymentIntentId: {
+      type: String,
+      index: true,
+    },
+  },
+  { timestamps: true }
+);
+
+// Ensure immutability of transactions (no updates allowed after creation)
+transactionSchema.pre("findOneAndUpdate", function (next) {
+  return next(
+    new Error("Transactions are immutable and cannot be updated.")
+  );
+});
+
+transactionSchema.pre("updateOne", function (next) {
+  return next(
+    new Error("Transactions are immutable and cannot be updated.")
+  );
+});
+
+transactionSchema.pre("deleteOne", function (next) {
+  return next(
+    new Error("Transactions are immutable and cannot be deleted.")
+  );
+});
+
+transactionSchema.pre("remove", function (next) {
+  return next(
+    new Error("Transactions are immutable and cannot be removed.")
+  );
+});
+
+export const Transaction = mongoose.model("Transaction", transactionSchema);


### PR DESCRIPTION
This pull request introduces a new Mongoose model for handling transactions in the system. The model enforces strict immutability, ensuring that once a transaction is created, it cannot be updated or deleted. The schema supports different transaction types, statuses, payment methods, and associations to users and related entities.

**New Transaction Model Implementation:**

* Added `transactionSchema` with fields for `userId`, `type`, `amount`, `status`, `paymentMethod`, `description`, `relatedEntity`, and `stripePaymentIntentId`, including validation rules and enums for transaction type and status. (`server/src/features/transactions/transaction.model.js`)

**Immutability Enforcement:**

* Implemented Mongoose pre-hooks (`findOneAndUpdate`, `updateOne`, `deleteOne`, `remove`) to throw errors if any update or deletion operation is attempted on a transaction, ensuring transactions cannot be modified or removed after creation. (`server/src/features/transactions/transaction.model.js`)

**Model Export:**

* Exported the `Transaction` model for use throughout the application. (`server/src/features/transactions/transaction.model.js`)