### PR TITLE
feat(events): add create trip endpoint and configure auth/role middlewares

### DIFF
--- a/server/src/features/events/event.controller.js
+++ b/server/src/features/events/event.controller.js
@@ -1,0 +1,20 @@
+import * as eventService from './event.service.js';
+import { createTripSchema } from './event.validation.js';
+import ApiResponse from '../../utils/ApiResponse.js';
+import ApiError from '../../utils/ApiError.js';
+
+export const createTrip = async (req, res, next) => {
+  try {
+    // 1️⃣ Validate request body
+    const { error } = createTripSchema.validate(req.body);
+    if (error) throw new ApiError(400, error.details[0].message);
+
+    // 2️⃣ Call service
+    const newTrip = await eventService.createTrip(req.body, req.user.id);
+
+    // 3️⃣ Send success response
+    return res.status(201).json(new ApiResponse(201, newTrip, 'Trip created successfully'));
+  } catch (err) {
+    next(err);
+  }
+};

--- a/server/src/features/events/event.route.js
+++ b/server/src/features/events/event.route.js
@@ -1,0 +1,16 @@
+import express from 'express';
+import { createTrip } from './event.controller.js';
+import auth from '../../middlewares/auth.middleware.js';
+import role from '../../middlewares/role.middleware.js';
+
+const router = express.Router();
+
+// POST /api/admin/trips
+router.post(
+  '/admin/trips',
+  auth,
+  role(['admin', 'events_office']),
+  createTrip
+);
+
+export default router;

--- a/server/src/features/events/event.service.js
+++ b/server/src/features/events/event.service.js
@@ -1,0 +1,21 @@
+import { Event } from './event.model.js';
+import ApiError from '../../utils/ApiError.js';
+
+export const createTrip = async (tripData, createdBy) => {
+  if (isNaN(tripData.price)) {
+    throw new ApiError(400, 'Price must be a valid number');
+  }
+
+  // Ensure end date is after start date
+  if (new Date(tripData.endDate) <= new Date(tripData.startDate)) {
+    throw new ApiError(400, 'End date must be after start date');
+  }
+
+  const newTrip = await Event.create({
+    ...tripData,
+    eventType: 'trip',
+    createdBy
+  });
+
+  return newTrip;
+};

--- a/server/src/features/events/event.validation.js
+++ b/server/src/features/events/event.validation.js
@@ -1,0 +1,12 @@
+import Joi from 'joi';
+
+export const createTripSchema = Joi.object({
+  name: Joi.string().trim().required(),
+  location: Joi.string().trim().required(),
+  description: Joi.string().trim().required(),
+  startDate: Joi.date().required(),
+  endDate: Joi.date().required(),
+  registrationDeadline: Joi.date().required(),
+  price: Joi.number().positive().required(),
+  capacity: Joi.number().integer().min(1).optional()
+});

--- a/server/src/middlewares/auth.middleware.js
+++ b/server/src/middlewares/auth.middleware.js
@@ -1,0 +1,13 @@
+// src/middlewares/auth.middleware.js
+
+// Temporary middleware for development (no token required)
+const auth = (req, res, next) => {
+  // Pretend this user is logged in
+  req.user = {
+    id: '6700aa92fe2d3a8712f97b21',     // fake user ID
+    role: 'admin'            // or 'events_office'
+  };
+  next();
+};
+
+export default auth;

--- a/server/src/middlewares/role.middleware.js
+++ b/server/src/middlewares/role.middleware.js
@@ -1,0 +1,16 @@
+// src/middlewares/role.middleware.js
+import ApiError from '../utils/ApiError.js';
+
+const role = (allowedRoles = []) => {
+  return (req, res, next) => {
+    if (!req.user || !req.user.role)
+      return next(new ApiError(401, 'Unauthorized: no user information found'));
+
+    if (!allowedRoles.includes(req.user.role))
+      return next(new ApiError(403, 'Forbidden: insufficient permissions'));
+
+    next();
+  };
+};
+
+export default role;

--- a/server/src/middlewares/validate.middleware.js
+++ b/server/src/middlewares/validate.middleware.js
@@ -1,0 +1,16 @@
+// src/middlewares/validate.middleware.js
+import ApiError from '../utils/ApiError.js';
+
+const validate = (schema) => {
+  return (req, res, next) => {
+    if (!schema) return next();
+
+    const { error } = schema.validate(req.body, { abortEarly: true });
+    if (error) {
+      return next(new ApiError(400, error.details[0].message));
+    }
+    next();
+  };
+};
+
+export default validate;

--- a/server/src/routes/index.js
+++ b/server/src/routes/index.js
@@ -1,4 +1,6 @@
 import express from 'express';
+import eventRoutes from '../features/events/event.route.js';
+
 
 const router = express.Router();
 
@@ -8,6 +10,7 @@ router.get('/', (req, res) => {
 });
 
 // TODO: Add feature routes here later
+router.use('/', eventRoutes);     // Mount all event-related endpoints
 // import authRoutes from '../features/auth/auth.route.js';
 // router.use('/auth', authRoutes);
 


### PR DESCRIPTION
- Added POST /api/admin/trips endpoint to allow Events Office or Admin users to create new trips
- Implemented validation for required fields (name, location, price, startDate, endDate, description)
- Linked event.controller, event.service, and event.model for trip creation logic
- Configured and finalized middleware files:
  - auth.middleware.js → added temporary fake user for testing
  - role.middleware.js → added role-based access control (admin, events_office)
  - error.middleware.js → handles global API errors
- Updated routes structure to correctly mount event routes under /api
- Successfully tested endpoint with Postman (returns 201 Created and saves trip in MongoDB)