### PR TITLE
feat(events): create an endpoint to list bazaars for vendors

### DIFF
--- a/server/src/features/events/event.controller.js
+++ b/server/src/features/events/event.controller.js
@@ -22,7 +22,38 @@ export class EventsController {
     }
   }
 
-  // Add more controller methods here as needed
+  async getEvents(req, res, next) {
+    try {
+      // Only allow access to authenticated users with 'vendor' role
+      if (!req.user) {
+        throw new ApiError(401, "Unauthorized");
+      }
+      if (req.user.role !== "vendor") {
+        throw new ApiError(
+          403,
+          "Forbidden: Only vendors can access this endpoint"
+        );
+      }
+
+      // Filter by type=bazaar if provided
+      const { type } = req.query;
+      let filter = {};
+      if (type === "bazaar") {
+        filter = {
+          eventType: "bazaar",
+          status: "approved",
+          startDate: { $gte: new Date() },
+        };
+      }
+
+      const events = await eventService.getEvents(filter);
+      return res
+        .status(200)
+        .json(new ApiResponse(200, events, "Events fetched successfully"));
+    } catch (err) {
+      next(err);
+    }
+  }
 }
 
 export default EventsController;

--- a/server/src/features/events/event.route.js
+++ b/server/src/features/events/event.route.js
@@ -13,5 +13,11 @@ router.post(
   role(["admin", "events_office"]),
   eventsController.createTrip.bind(eventsController)
 );
-
+// GET /api/events?type=bazaar
+router.get(
+  "/",
+  auth,
+  role(["vendor"]),
+  eventsController.getEvents.bind(eventsController)
+);
 export default router;

--- a/server/src/features/events/event.service.js
+++ b/server/src/features/events/event.service.js
@@ -1,21 +1,25 @@
-import { Event } from './event.model.js';
-import ApiError from '../../utils/ApiError.js';
+import { Event } from "./event.model.js";
+import ApiError from "../../utils/ApiError.js";
 
 export const createTrip = async (tripData, createdBy) => {
   if (isNaN(tripData.price)) {
-    throw new ApiError(400, 'Price must be a valid number');
+    throw new ApiError(400, "Price must be a valid number");
   }
 
   // Ensure end date is after start date
   if (new Date(tripData.endDate) <= new Date(tripData.startDate)) {
-    throw new ApiError(400, 'End date must be after start date');
+    throw new ApiError(400, "End date must be after start date");
   }
 
   const newTrip = await Event.create({
     ...tripData,
-    eventType: 'trip',
-    createdBy
+    eventType: "trip",
+    createdBy,
   });
 
   return newTrip;
+};
+// Get events with optional filter (e.g., for bazaar, published, upcoming)
+export const getEvents = async (filter = {}) => {
+  return Event.find(filter).sort({ startDate: 1 });
 };


### PR DESCRIPTION
REQ 91
This pull request adds a new endpoint to allow authenticated vendors to fetch upcoming, approved bazaar events. It introduces a controller method, updates routing to expose the endpoint, and implements a service-layer function to fetch filtered events from the database.

**New endpoint for vendor event access:**

* Added a `getEvents` method to `EventsController` that restricts access to authenticated users with the 'vendor' role and allows filtering for upcoming, approved bazaar events.
* Registered the new `GET /api/events?type=bazaar` route in `event.route.js`, protected by authentication and vendor role middleware.

**Service layer enhancements:**

* Implemented a `getEvents` function in `event.service.js` to retrieve events from the database with optional filters and sorted by start date.