### PR TITLE
feat(applications): enhance application endpoint to accept full details

### DIFF
--- a/server/src/features/applications/application.model.js
+++ b/server/src/features/applications/application.model.js
@@ -26,8 +26,8 @@ const applicationSchema = new mongoose.Schema(
     },
     staff: [
       {
-        name: { type: String },
-        email: { type: String },
+        name: { type: String, required: true },
+        email: { type: String, required: true },
         id: { type: String },
       },
     ],

--- a/server/src/features/applications/application.validation.js
+++ b/server/src/features/applications/application.validation.js
@@ -22,6 +22,6 @@ export const applyToBazaarSchema = Joi.object({
       "any.required": "Staff details are required.",
     }),
   // Add other required fields from your form here
-  durationWeeks: Joi.number().integer().min(1).required(),
+  durationWeeks: Joi.number().integer().min(1).max(4).required(),
   locationPreference: Joi.string().optional().allow(""), // .allow('') makes it optional but not null
 });


### PR DESCRIPTION
This pull request introduces stricter validation and schema requirements for staff details in applications, and limits the allowed duration for applications to a maximum of four weeks. The key changes are as follows:

**Schema and Validation Updates**

* The `staff` array in `application.model.js` now requires both the `name` and `email` fields for each staff member, ensuring that incomplete staff entries cannot be saved to the database.
* The `durationWeeks` field in the application validation schema is now limited to a maximum of 4 weeks, preventing users from submitting applications with a longer duration.