### PR TITLE
feat(events): implement workshop creation with validation and role restriction

### DIFF
--- a/server/src/features/events/event.controller.js
+++ b/server/src/features/events/event.controller.js
@@ -1,10 +1,8 @@
-import { createTripSchema } from "./event.validation.js";
 import ApiError from "../../utils/ApiError.js";
 import ApiResponse from "../../utils/ApiResponse.js";
 import * as eventService from "./event.service.js";
 import { Event } from './event.model.js';
-import { workshopStatusSchema } from './event.validation.js';
-import { createConferenceSchema } from "./event.validation.js";
+import { createTripSchema, workshopStatusSchema, createWorkshopSchema, createConferenceSchema } from './event.validation.js';
 
 //Write your code in this class!!!
 
@@ -94,7 +92,26 @@ async getEvents(req, res, next) {
       next(err);
     }
   }
-  
+
+  async createWorkshop(req, res, next) {
+  try {
+    
+    if (req.user.role !== 'professor') {
+      return res.status(403).json({ message: 'Forbidden: Only professors can create workshops' });
+    }
+    
+    const { error } = createWorkshopSchema.validate(req.body);
+    if (error) throw new ApiError(400, error.details[0].message);
+    
+    const newWorkshop = await eventService.createWorkshop(req.body, req.user._id);
+
+    return res
+      .status(201)
+      .json(new ApiResponse(201, newWorkshop, "Workshop created successfully"));
+    } catch (err) {
+      next(err);
+  } 
+} 
 
 // Accept workshop
 async acceptWorkshop(req, res) {
@@ -148,13 +165,5 @@ async rejectWorkshop(req, res) {
   } catch (error) {
     res.status(500).json({ message: 'Error rejecting workshop', error });
   }
+ }
 }
-
-
-
-
-}
-
-
-
-

--- a/server/src/features/events/event.route.js
+++ b/server/src/features/events/event.route.js
@@ -1,7 +1,5 @@
 import express from 'express';
 import {EventsController} from './event.controller.js';
-import auth from "../../middlewares/auth.middleware.js";
-import role from "../../middlewares/role.middleware.js";
 import authMiddleware from '../../middlewares/auth.middleware.js';
 import roleMiddleware from '../../middlewares/role.middleware.js';
 
@@ -16,32 +14,35 @@ router.post(
   eventsController.createBazaar    // controller we created
 );
 
+// Create workshop
+router.post('/workshops', authMiddleware, roleMiddleware(['professor']), eventsController.createWorkshop.bind(eventsController));
+
 // Accept workshop
-router.patch('/:id/accept', auth, role(['events_office']), eventsController.acceptWorkshop);
+router.patch('/:id/accept', authMiddleware, roleMiddleware(['events_office']), eventsController.acceptWorkshop.bind(eventsController));
 
 // Reject workshop
-router.patch('/:id/reject', auth, role(['events_office']), eventsController.rejectWorkshop);
+router.patch('/:id/reject', authMiddleware, roleMiddleware(['events_office']), eventsController.rejectWorkshop.bind(eventsController));
 
 // POST /api/admin/trips
 router.post(
   "/admin/trips",
-  auth,
-  role(["admin", "events_office"]),
+  authMiddleware,
+  roleMiddleware(["admin", "events_office"]),
   eventsController.createTrip.bind(eventsController)
 );
 
 // GET /api/events?type=bazaar
 router.get(
   "/",
-  auth,
-  role(["vendor"]),
+  authMiddleware,
+  roleMiddleware(["vendor"]),
   eventsController.getEvents.bind(eventsController)
 );
 
 router.post(
   "/admin/conferences",
-  auth,
-  role(["admin", "events_office"]),
+  authMiddleware,
+  roleMiddleware(["admin", "events_office"]),
   eventsController.createConferenceController
 );
 

--- a/server/src/features/events/event.service.js
+++ b/server/src/features/events/event.service.js
@@ -91,3 +91,15 @@ export const createConference = async (data, userId) => {
 export const getEvents = async (filter = {}) => {
   return Event.find(filter).sort({ startDate: 1 });
 };
+
+export const createWorkshop = async (workshopData, professorId) => {
+
+  const workshop = await Event.create({
+    ...workshopData,
+    eventType: "workshop",
+    createdBy: professorId,
+    status: "pending"
+  });
+
+  return workshop;
+};

--- a/server/src/features/events/event.validation.js
+++ b/server/src/features/events/event.validation.js
@@ -41,3 +41,102 @@ export const workshopStatusSchema = Joi.object({
   id: Joi.string().custom(objectId).required(),
   status: Joi.string().valid('approved', 'rejected').required()
 });
+
+export const createWorkshopSchema = Joi.object({
+  name: Joi.string().trim().required().messages({
+    "any.required": "Workshop name is required",
+    "string.base": "Workshop name must be text",
+  }),
+
+  eventType: Joi.string()
+    .valid("workshop")
+    .default("workshop")
+    .messages({
+      "any.only": "Event type must be 'workshop'",
+    }),
+
+  description: Joi.string().required().messages({
+    "any.required": "Workshop description is required",
+    "string.base": "Description must be text",
+  }),
+
+  location: Joi.string()
+    .valid("GUC Cairo", "GUC Berlin")
+    .required()
+    .messages({
+      "any.required": "Workshop location is required",
+      "any.only": "Location must be either 'GUC Cairo' or 'GUC Berlin'",
+    }),
+
+  startDate: Joi.date().required().messages({
+    "any.required": "Workshop start date is required",
+    "date.base": "Invalid start date format",
+  }),
+
+  endDate: Joi.date()
+    .greater(Joi.ref("startDate"))
+    .required()
+    .messages({
+      "any.required": "Workshop end date is required",
+      "date.base": "Invalid end date format",
+      "date.greater": "End date must be after start date",
+    }),
+
+  registrationDeadline: Joi.date()
+    .less(Joi.ref("startDate"))
+    .required()
+    .messages({
+      "any.required": "Registration deadline is required",
+      "date.base": "Invalid registration deadline format",
+      "date.less": "Registration deadline must be before start date",
+    }),
+
+  status: Joi.string()
+    .valid("pending")
+    .default("pending")
+    .messages({
+      "any.only": "Status must be: pending",
+    }),
+
+  capacity: Joi.number().integer().min(1).optional().messages({
+    "number.base": "Capacity must be a number",
+    "number.min": "Capacity must be at least 1",
+  }),
+
+  agenda: Joi.string().required().messages({
+    "any.required": "Workshop agenda is required",
+    "string.base": "Agenda must be text",
+  }),
+
+  requiredBudget: Joi.number().required().messages({
+    "any.required": "Required budget is required",
+    "number.base": "Required budget must be a number",
+  }),
+
+  fundingSource: Joi.string()
+    .valid("external", "guc")
+    .required()
+    .messages({
+      "any.required": "Funding source is required",
+      "any.only": "Funding source must be either 'external' or 'guc'",
+    }),
+
+  extraResources: Joi.string().optional().messages({
+    "string.base": "Extra resources must be text",
+  }),
+
+  faculty: Joi.string().required().messages({
+    "any.required": "Faculty is required (e.g., MET, IET, etc.)",
+    "string.base": "Faculty must be text",
+  }),
+
+  professors: Joi.array()
+    .items(Joi.string().hex().length(24))
+    .min(1)
+    .required()
+    .messages({
+      "any.required": "At least one professor is required",
+      "array.min": "Professors list must contain at least one ID",
+      "string.hex": "Professor IDs must be valid ObjectIds",
+    }),
+});

--- a/server/src/middlewares/auth.middleware.js
+++ b/server/src/middlewares/auth.middleware.js
@@ -5,8 +5,8 @@ export default (req, res, next) => {
   // Simulate a logged-in user (you can change role depending on who's testing)
   req.user = {
     _id: '66f123abc987de0012f9f999', // fake MongoDB ObjectId string
-    name: 'Test Events Office User',
-    role: 'EventsOffice', // change to 'admin' if needed
+    name: 'Test Professor User',
+    role: 'professor', // change to 'admin' if needed
   };
 
   next();


### PR DESCRIPTION
This pull request adds support for professors to create new workshops via the API, including input validation, service logic, and appropriate access control. It introduces a new `createWorkshop` controller and route, a comprehensive Joi schema for workshop validation, and ensures only authorized users can access these endpoints. Middleware usage is also standardized throughout the event routes.

Key changes:

**Workshop Creation Feature:**

* Added `createWorkshop` controller method in `event.controller.js` to handle workshop creation, including role-based access control for professors and input validation using a new schema.
* Implemented `createWorkshop` service in `event.service.js` to create a new workshop event with default status and creator information.
* Introduced `createWorkshopSchema` in `event.validation.js` for comprehensive validation of workshop creation input, covering fields like name, description, dates, location, professors, and more.

**API & Middleware Updates:**

* Added a new POST `/workshops` route in `event.route.js` for workshop creation, protected by `authMiddleware` and `roleMiddleware(['professor'])`. Also updated all event routes to consistently use the new middleware names and binding.
* Updated the mock user in `auth.middleware.js` to have the role of `professor` for testing the new workshop creation feature.

**Code Cleanup & Imports:**

* Consolidated imports from `event.validation.js` in `event.controller.js` for better maintainability.
* Minor cleanup of trailing empty lines in `event.controller.js`.