### PR TITLE
feat(applications): create an endpoint to fetch vendor's applications by status

### DIFF
--- a/server/src/features/applications/application.controller.js
+++ b/server/src/features/applications/application.controller.js
@@ -26,4 +26,23 @@ export class ApplicationController {
       next(error);
     }
   }
+  async getMyApplications(req, res, next) {
+    try {
+      const vendorId = req.user._id;
+      const filters = req.query; // Get filters from query string (e.g., ?status=accepted)
+
+      const applications = await ApplicationService.findVendorApplications(
+        vendorId,
+        filters
+      );
+
+      res.status(200).json({
+        success: true,
+        message: "Applications retrieved successfully.",
+        data: applications,
+      });
+    } catch (error) {
+      next(error);
+    }
+  }
 }

--- a/server/src/features/applications/application.route.js
+++ b/server/src/features/applications/application.route.js
@@ -1,9 +1,10 @@
 import express from "express";
 import { ApplicationController } from "./application.controller.js";
-import { applyToBazaarSchema } from "./application.validation.js";
+import { applyToBazaarSchema , getMyApplicationsSchema} from "./application.validation.js";
 import validate from "../../middlewares/validate.middleware.js";
 import role from "../../middlewares/role.middleware.js";
 import authMiddleware from "../../middlewares/auth.middleware.js";
+import validateQuery from "../../middlewares/validateQuery.middleware.js";
 
 const router = express.Router();
 const applicationController = new ApplicationController();
@@ -17,4 +18,11 @@ router.post(
   applicationController.applyToBazaar.bind(applicationController)
 );
 
+router.get(
+  "/me",
+  authMiddleware,
+  role(["vendor"]),
+  validateQuery(getMyApplicationsSchema), // Use the new middleware here
+  applicationController.getMyApplications.bind(applicationController)
+);
 export default router;

--- a/server/src/features/applications/application.service.js
+++ b/server/src/features/applications/application.service.js
@@ -18,6 +18,27 @@ class ApplicationServiceClass {
       throw new Error(`Could not create application: ${error.message}`);
     }
   }
+  /**
+   * Finds all applications for a specific vendor, with optional filtering and population.
+   * @param {string} vendorId - The ID of the authenticated vendor.
+   * @param {object} filters - An object containing query filters like { status: 'accepted' }.
+   * @returns {Promise<Array>} A list of application documents.
+   */
+  async findVendorApplications(vendorId, filters = {}) {
+    const query = { vendorId };
+
+    // Conditionally add the status to the query if it exists in the filters
+    if (filters.status) {
+      query.status = filters.status;
+    }
+
+    const applications = await Application.find(query)
+      // Populate 'bazaarId' with specific fields from the linked Event/Bazaar document
+      .populate("bazaarId", "name description startDate endDate location")
+      .sort({ createdAt: -1 }); // Sort by newest first
+
+    return applications;
+  }
 }
 
 export const ApplicationService = new ApplicationServiceClass();

--- a/server/src/features/applications/application.validation.js
+++ b/server/src/features/applications/application.validation.js
@@ -25,3 +25,7 @@ export const applyToBazaarSchema = Joi.object({
   durationWeeks: Joi.number().integer().min(1).max(4).required(),
   locationPreference: Joi.string().optional().allow(""), // .allow('') makes it optional but not null
 });
+
+export const getMyApplicationsSchema = Joi.object({
+  status: Joi.string().valid("pending", "accepted", "rejected").optional(),
+});

--- a/server/src/middlewares/validateQuery.middleware.js
+++ b/server/src/middlewares/validateQuery.middleware.js
@@ -1,0 +1,15 @@
+import ApiError from '../utils/ApiError.js';
+
+const validateQuery = (schema) => {
+  return (req, res, next) => {
+    if (!schema) return next();
+
+    const { error } = schema.validate(req.query, { abortEarly: true });
+    if (error) {
+      return next(new ApiError(400, error.details[0].message));
+    }
+    next();
+  };
+};
+
+export default validateQuery;


### PR DESCRIPTION
REQ 97
This pull request adds a new endpoint for vendors to retrieve their own applications with optional filtering, along with input validation for query parameters. It introduces a new controller method, service logic, validation schema, and middleware to support this feature.

**New "My Applications" endpoint for vendors:**

* Added `getMyApplications` method to `ApplicationController` to fetch applications for the authenticated vendor, supporting query-based filtering (e.g., by status).
* Added a new route `GET /applications/me` for vendors, protected by authentication and role checks, and using the new query validation middleware.

**Service and validation enhancements:**

* Implemented `findVendorApplications` in `ApplicationService` to retrieve applications for a vendor, with optional status filtering and population of related bazaar/event fields.
* Added `getMyApplicationsSchema` using Joi to validate allowed query parameters (currently only `status`).
* Introduced `validateQuery` middleware to validate query parameters against a Joi schema, returning a 400 error on validation failure.

**Supporting changes:**

* Updated imports in `application.route.js` to include new validation schema and middleware.