### PR TITLE
feat(facilities): create an endpoint to fetch court bookings schedules

### DIFF
--- a/server/src/features/facilities/facility.controller.js
+++ b/server/src/features/facilities/facility.controller.js
@@ -1,0 +1,20 @@
+import { FacilitiesService } from "./facility.service.js";
+
+export class FacilitiesController {
+  /**
+   * Handles the request to get all court schedules.
+   */
+  async getCourtSchedules(req, res, next) {
+    try {
+      const schedules = await FacilitiesService.getCourtSchedules();
+
+      res.status(200).json({
+        success: true,
+        message: "Court schedules retrieved successfully.",
+        data: schedules,
+      });
+    } catch (error) {
+      next(error);
+    }
+  }
+}

--- a/server/src/features/facilities/facility.route.js
+++ b/server/src/features/facilities/facility.route.js
@@ -1,0 +1,21 @@
+import express from "express";
+import { FacilitiesController } from "./facility.controller.js";
+import authMiddleware from "../../middlewares/auth.middleware.js";
+
+const router = express.Router();
+const facilitiesController = new FacilitiesController();
+
+/**
+ * @route   GET /api/facilities/courts
+ * @desc    Get schedules for all court facilities
+ * @access  Private (All authenticated users)
+ */
+router.get(
+  "/courts",
+  authMiddleware, // Ensures the user is logged in
+  facilitiesController.getCourtSchedules.bind(
+    facilitiesController.getCourtSchedules
+  )
+);
+
+export default router;

--- a/server/src/features/facilities/facility.service.js
+++ b/server/src/features/facilities/facility.service.js
@@ -1,0 +1,48 @@
+import { CourtBooking } from "./facility.model.js";
+
+class FacilitiesServiceClass {
+  /**
+   * Fetches all upcoming court bookings and structures them by court type.
+   * @returns {Promise<Object>} A structured object with court types as keys.
+   */
+  async getCourtSchedules() {
+    // Get the start of today to only fetch future and current-day bookings
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+
+    // Find all active bookings from today onwards
+    const activeBookings = await CourtBooking.find({
+      status: "active",
+      date: { $gte: today },
+    }).sort({ date: 1, startTime: 1 }); // Sort by date and time
+
+    // Initialize the structure to ensure all court types are present in the response
+    const initialSchedule = {
+      basketball: [],
+      tennis: [],
+      football: [],
+    };
+
+    // Use reduce to group the flat array of bookings into the desired structure
+    const structuredSchedule = activeBookings.reduce((acc, booking) => {
+      // Create a clean schedule entry object
+      const scheduleEntry = {
+        date: booking.date,
+        startTime: booking.startTime,
+        endTime: booking.endTime,
+        status: booking.status, // Use the real status from the DB
+      };
+
+      // Push the entry into the correct array based on its courtType
+      if (acc[booking.courtType]) {
+        acc[booking.courtType].push(scheduleEntry);
+      }
+
+      return acc;
+    }, initialSchedule);
+
+    return structuredSchedule;
+  }
+}
+
+export const FacilitiesService = new FacilitiesServiceClass();

--- a/server/src/routes/index.js
+++ b/server/src/routes/index.js
@@ -2,7 +2,7 @@
 import express from 'express';
 import eventRoutes from '../features/events/event.route.js'
 import applicationRoutes from '../features/applications/application.route.js';
-
+import facilityRoutes from '../features/facilities/facility.route.js';
 const PORT = process.env.PORT || 5000;
 const router = express.Router();
 
@@ -15,4 +15,6 @@ router.get('/', (req, res) => {
 router.use('/events', eventRoutes);
 // Applications routes
 router.use('/applications', applicationRoutes);
+//facilities routes
+router.use('/facilities', facilityRoutes);
 export default router;


### PR DESCRIPTION
This pull request introduces a new API endpoint to retrieve the schedules for all court facilities, grouped by court type. It includes the implementation of the service, controller, and route, as well as integration into the main router. The endpoint is protected and only accessible to authenticated users.

**New Facilities Court Schedules Endpoint**

* **Service Layer Implementation:**
  - Added `FacilitiesService.getCourtSchedules` in `facility.service.js` to fetch all active and upcoming court bookings, grouping them by court type (basketball, tennis, football). The service ensures only bookings from today onwards are included and structures the response for easy consumption.

* **Controller and Route Setup:**
  - Created `FacilitiesController.getCourtSchedules` in `facility.controller.js` to handle incoming requests and return the structured schedules.
  - Added a new route `/api/facilities/courts` in `facility.route.js`, protected by authentication middleware, to expose the controller method.

* **Integration with Main Router:**
  - Registered the facilities routes in the main router so that `/facilities` endpoints are available in the API. [[1]](diffhunk://#diff-475aa6062062c0a7a00a6edd49daaa93787a162c9f69eed76048e82bd1267a2dL5-R5) [[2]](diffhunk://#diff-475aa6062062c0a7a00a6edd49daaa93787a162c9f69eed76048e82bd1267a2dR18-R19)