### PR TITLE
feat(events): add authorization checks for workshop creation and fetching user workshops

### DIFF
--- a/server/src/features/events/event.controller.js
+++ b/server/src/features/events/event.controller.js
@@ -93,11 +93,14 @@ async getEvents(req, res, next) {
     }
   }
 
-  async createWorkshop(req, res, next) {
+async createWorkshop(req, res, next) {
   try {
+    if (!req.user) {
+      throw new ApiError(401, "Unauthorized");
+    }
     
     if (req.user.role !== 'professor') {
-      return res.status(403).json({ message: 'Forbidden: Only professors can create workshops' });
+      throw new ApiError(403, "Forbidden: Only professors can create workshops");
     }
     
     const { error } = createWorkshopSchema.validate(req.body);
@@ -112,6 +115,27 @@ async getEvents(req, res, next) {
       next(err);
   } 
 } 
+
+async getMyWorkshops(req, res, next) {
+  try {
+    if (!req.user) {
+      throw new ApiError(401, "Unauthorized");
+    }
+    
+    if (req.user.role !== "professor") {
+      throw new ApiError(403, "Forbidden: Only professors can view their workshops");
+    }
+    
+    const events = await eventService.getEvents({eventType:"workshop", createdBy: req.user._id});
+
+    return res
+    .status(200)
+    .json(new ApiResponse(200, events, "Workshops fetched successfully"));
+
+  } catch (error) {
+    next(error);
+  }
+}
 
 // Accept workshop
 async acceptWorkshop(req, res) {

--- a/server/src/features/events/event.route.js
+++ b/server/src/features/events/event.route.js
@@ -17,6 +17,9 @@ router.post(
 // Create workshop
 router.post('/workshops', authMiddleware, roleMiddleware(['professor']), eventsController.createWorkshop.bind(eventsController));
 
+//  Get my workshops
+router.get('/me/workshops', authMiddleware, roleMiddleware(['professor']), eventsController.getMyWorkshops.bind(eventsController));
+
 // Accept workshop
 router.patch('/:id/accept', authMiddleware, roleMiddleware(['events_office']), eventsController.acceptWorkshop.bind(eventsController));
 


### PR DESCRIPTION
This pull request enhances the workshops feature for professors by improving authorization checks and adding a new endpoint for professors to view their own workshops. The most important changes are grouped below:

**Authorization Improvements:**

* Updated the `createWorkshop` controller to throw standardized `ApiError` exceptions for unauthorized and forbidden access, ensuring consistent error handling when non-professors or unauthenticated users attempt to create workshops.

**New Feature: Professors Viewing Their Workshops**

* Added a new controller method `getMyWorkshops` in `event.controller.js` that allows professors to fetch workshops they have created, with proper authorization checks.
* Introduced a new route `/me/workshops` in `event.route.js` for professors to access their workshops, protected by authentication and role middleware.…hing user workshops