### PR TITLE
feat(events): add endpoint to fetch logged-in user's registered events

### DIFF
--- a/server/src/features/events/event.controller.js
+++ b/server/src/features/events/event.controller.js
@@ -166,4 +166,28 @@ async rejectWorkshop(req, res) {
     res.status(500).json({ message: 'Error rejecting workshop', error });
   }
  }
+ // Get all events the logged-in user registered for
+async getMyEvents(req, res, next) {
+  try {
+    // Ensure user is authenticated
+    if (!req.user) {
+      throw new ApiError(401, "Unauthorized");
+    }
+
+    // Get the user ID from auth middleware
+    const userId = req.user._id;
+
+    // Fetch events the user is registered for
+    const events = await eventService.getEventsByUser(userId);
+
+    // Send response
+    return res
+      .status(200)
+      .json(new ApiResponse(200, events, "Registered events fetched successfully"));
+  } catch (err) {
+    next(err);
+  }
+}
+
+
 }

--- a/server/src/features/events/event.route.js
+++ b/server/src/features/events/event.route.js
@@ -46,4 +46,10 @@ router.post(
   eventsController.createConferenceController
 );
 
+router.get(
+  "/me/events",
+  authMiddleware, // user must be logged in
+  eventsController.getMyEvents.bind(eventsController)
+);
+
 export default router;

--- a/server/src/features/events/event.service.js
+++ b/server/src/features/events/event.service.js
@@ -103,3 +103,8 @@ export const createWorkshop = async (workshopData, professorId) => {
 
   return workshop;
 };
+
+export const getEventsByUser = async (userId) => {
+  const events = await Event.find({ attendees: userId });
+  return events;
+};


### PR DESCRIPTION
Implemented a new endpoint that allows authenticated users (Students, Staff, TAs, or Professors) to view all events they are registered for. The endpoint retrieves all event documents where the user’s ID appears in the attendees array.