### PR TITLE
feat(facilities): implement gym session creation with validation and role restrictions

### DIFF
--- a/server/src/features/facilities/facility.controller.js
+++ b/server/src/features/facilities/facility.controller.js
@@ -1,4 +1,6 @@
 import { FacilitiesService } from "./facility.service.js";
+import ApiError from "../../utils/ApiError.js";
+import { createGymSessionSchema } from "./facility.validation.js";
 
 export class FacilitiesController {
   /**
@@ -12,6 +14,35 @@ export class FacilitiesController {
         success: true,
         message: "Court schedules retrieved successfully.",
         data: schedules,
+      });
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /**
+   * Handles the request to create a new gym session.
+   */
+  async createGymSession(req, res, next) {
+  try {
+
+    if (!req.user) {
+      throw new ApiError(401, "Unauthorized");
+    }
+    
+    if (req.user.role !== "events_office" && req.user.role !== "admin") {
+      throw new ApiError(403, "Only Events Office or Admin can create gym sessions.");
+    }
+        
+    const { error } = createGymSessionSchema.validate(req.body);
+    if (error) throw new ApiError(400, error.details[0].message)
+
+    const session = await FacilitiesService.createGymSession(req.body);
+
+    res.status(201).json({
+       success: true,
+       message: "Gym session created successfully.",
+       data: session,
       });
     } catch (error) {
       next(error);

--- a/server/src/features/facilities/facility.route.js
+++ b/server/src/features/facilities/facility.route.js
@@ -18,4 +18,15 @@ router.get(
   )
 );
 
+/**
+ * @route   POST /api/facilities/admin/gym/sessions
+ * @desc    Create a new gym session (Admin or Events Office only)
+ * @access  Private
+ */
+router.post(
+  "/admin/gym/sessions",
+  authMiddleware,
+  facilitiesController.createGymSession.bind(facilitiesController)
+);
+
 export default router;

--- a/server/src/features/facilities/facility.service.js
+++ b/server/src/features/facilities/facility.service.js
@@ -1,5 +1,4 @@
 import { CourtBooking, GymSession } from "./facility.model.js";
-import { createGymSessionSchema } from "./facility.validation.js";
 
 class FacilitiesServiceClass {
   /**

--- a/server/src/features/facilities/facility.service.js
+++ b/server/src/features/facilities/facility.service.js
@@ -1,4 +1,5 @@
-import { CourtBooking } from "./facility.model.js";
+import { CourtBooking, GymSession } from "./facility.model.js";
+import { createGymSessionSchema } from "./facility.validation.js";
 
 class FacilitiesServiceClass {
   /**
@@ -43,6 +44,26 @@ class FacilitiesServiceClass {
 
     return structuredSchedule;
   }
-}
 
+  /**
+   * Creates a new gym session.
+   * @param {Object} data - Validated gym session data
+   * @param {Object} user - Authenticated user
+   */
+  async createGymSession(data) {
+  const { date, time, duration, type, instructorId, maxParticipants } = data;
+
+  const newSession = new GymSession({
+    date,
+    startTime: time,
+    durationMinutes: duration,
+    type,
+    instructor: instructorId,
+    maxParticipants: maxParticipants
+  });
+
+  await newSession.save();
+  return newSession;
+}
+}
 export const FacilitiesService = new FacilitiesServiceClass();

--- a/server/src/features/facilities/facility.validation.js
+++ b/server/src/features/facilities/facility.validation.js
@@ -1,0 +1,56 @@
+import Joi from "joi";
+import mongoose from "mongoose";
+
+export const createGymSessionSchema = Joi.object({
+  date: Joi.date().required().messages({
+    "any.required": "Date is required",
+    "date.base": "Date must be a valid date",
+  }),
+
+  time: Joi.string()
+    .pattern(/^(0?[1-9]|1[0-2]):[0-5][0-9]\s?(AM|PM)$/i)
+    .required()
+    .messages({
+      "any.required": "Time is required",
+      "string.pattern.base": "Time must be in format hh:mm AM/PM",
+    }),
+
+  duration: Joi.number().integer().min(15).max(240).required().messages({
+    "any.required": "Duration is required",
+    "number.base": "Duration must be a number",
+    "number.min": "Duration must be at least 15 minutes",
+    "number.max": "Duration cannot exceed 240 minutes",
+  }),
+
+  type: Joi.string()
+    .valid("yoga", "pilates", "aerobics", "zumba", "cross_circuit", "kick_boxing")
+    .required()
+    .messages({
+      "any.only":
+        "Invalid type. Must be one of yoga, pilates, aerobics, zumba, cross_circuit, or kick_boxing",
+    }),
+
+  instructorId: Joi.string()
+    .custom((value, helpers) => {
+      if (!mongoose.Types.ObjectId.isValid(value)) {
+        return helpers.error("any.invalid");
+      }
+      return value;
+    })
+    .required()
+    .messages({
+      "any.required": "Instructor ID is required",
+      "any.invalid": "Instructor ID must be a valid ObjectId",
+    }),
+
+  maxParticipants: Joi.number()
+    .integer()
+    .min(1)
+    .max(100)
+    .optional()
+    .messages({
+      "number.base": "Max participants must be a number",
+      "number.min": "There must be at least 1 participant allowed",
+      "number.max": "Max participants cannot exceed 100",
+    }),
+});


### PR DESCRIPTION
This pull request adds support for creating new gym sessions in the facilities feature. It introduces endpoint routing, controller logic, service methods, and input validation to allow admins and events office users to create gym sessions securely and with proper data validation.

**New Gym Session Creation Feature:**

* **API Endpoint & Routing**
  - Added a new POST endpoint at `/api/facilities/admin/gym/sessions` for creating gym sessions, accessible only by authenticated admins or events office users.

* **Controller Logic**
  - Implemented the `createGymSession` method in `FacilitiesController` to handle authorization (restricting to admins/events office), validate input, and delegate session creation to the service layer.
  - Imported necessary validation and error handling utilities in the controller.

* **Service Layer**
  - Added `createGymSession` method in `FacilitiesService` to handle the creation and saving of new `GymSession` documents.
  - Imported the `GymSession` model and validation schema into the service.

* **Input Validation**
  - Introduced a Joi schema (`createGymSessionSchema`) to validate gym session creation requests, ensuring correct formats and required fields for date, time, duration, type, instructor ID, and participant limits.