### PR TITLE
feat(facilities): add endpoint to fetch gym sessions by specific month and year with validation

### DIFF
--- a/server/src/features/facilities/facility.controller.js
+++ b/server/src/features/facilities/facility.controller.js
@@ -1,4 +1,6 @@
 import { FacilitiesService } from "./facility.service.js";
+import  ApiError  from "../../utils/ApiError.js";
+import { gymSessionsQuerySchema } from "./facility.validation.js";
 
 export class FacilitiesController {
   /**
@@ -17,4 +19,32 @@ export class FacilitiesController {
       next(error);
     }
   }
+
+  /**
+   * Handles the request to get all gym sessions during a specific month and year.
+   */
+  async getGymSessions(req, res, next) {
+  try {
+    if (!req.user) {
+      throw new ApiError(401, "Unauthorized");
+    }
+
+    const { error } = gymSessionsQuerySchema.validate(req.query);
+    if (error) throw new ApiError(400, error.details[0].message);
+    
+    const { month, year } = req.query;
+    const sessions = await FacilitiesService.getGymSessions(
+      parseInt(month),
+      parseInt(year)
+    );
+
+    res.status(200).json({
+      success: true,
+      message: "Gym sessions retrieved successfully.",
+      data: sessions,
+    });
+  } catch (error) {
+    next(error);
+  }
+}
 }

--- a/server/src/features/facilities/facility.model.js
+++ b/server/src/features/facilities/facility.model.js
@@ -1,4 +1,5 @@
 import mongoose from "mongoose";
+import "../users/user.model.js";
 
 // GymSession Schema
 

--- a/server/src/features/facilities/facility.route.js
+++ b/server/src/features/facilities/facility.route.js
@@ -18,4 +18,6 @@ router.get(
   )
 );
 
+router.get("/gym/sessions", authMiddleware, facilitiesController.getGymSessions.bind(facilitiesController));
+
 export default router;

--- a/server/src/features/facilities/facility.service.js
+++ b/server/src/features/facilities/facility.service.js
@@ -1,4 +1,4 @@
-import { CourtBooking } from "./facility.model.js";
+import { CourtBooking, GymSession } from "./facility.model.js";
 
 class FacilitiesServiceClass {
   /**
@@ -42,6 +42,32 @@ class FacilitiesServiceClass {
     }, initialSchedule);
 
     return structuredSchedule;
+  }
+  
+    /**
+   * @route   GET /api/facilities/gym/sessions
+   * @desc    Get all gym sessions for a specific month and year.
+   * @access  Private (All authenticated users)
+   * @query   month (1–12), year (4-digit)
+   * @success 200 OK - Returns { success, message, data: [sessionObjects] }
+   * @error   401 Unauthorized
+   */
+  async getGymSessions(month, year) {
+    if (!month || !year) {
+      throw new Error("Month and year parameters are required");
+    }
+
+    const startOfMonth = new Date(year, month - 1, 1);
+    const endOfMonth = new Date(year, month, 0, 23, 59, 59, 999);
+
+    const sessions = await GymSession.find({
+      date: { $gte: startOfMonth, $lte: endOfMonth },
+      deletedAt: null,
+    })
+      .populate("instructor", "name email role")
+      .sort({ date: 1, startTime: 1 });
+
+    return sessions;
   }
 }
 

--- a/server/src/features/facilities/facility.validation.js
+++ b/server/src/features/facilities/facility.validation.js
@@ -1,0 +1,26 @@
+import Joi from "joi";
+
+export const gymSessionsQuerySchema = Joi.object({
+  month: Joi.number()
+    .integer()
+    .min(1)
+    .max(12)
+    .required()
+    .messages({
+      "number.base": "Month must be a number",
+      "number.min": "Month must be between 1 and 12",
+      "number.max": "Month must be between 1 and 12",
+      "any.required": "Month is required",
+    }),
+  year: Joi.number()
+    .integer()
+    .min(2000)
+    .max(2100)
+    .required()
+    .messages({
+      "number.base": "Year must be a number",
+      "number.min": "Year must be between 2000 and 2100",
+      "number.max": "Year must be between 2000 and 2100",
+      "any.required": "Year is required",
+    }),
+});


### PR DESCRIPTION
This pull request adds a new feature that allows authenticated users to retrieve all gym sessions for a specific month and year through a new API endpoint. The implementation includes request validation, service logic, and route/controller integration. Additional minor improvements include model import adjustments.

**New Feature: Gym Sessions Query**

* Adds a new controller method `getGymSessions` in `facility.controller.js` to handle requests for gym sessions by month and year, including authentication and input validation. [[1]](diffhunk://#diff-830526ce9a9dc1e58c2fa4a045a56e6e5c42a80e6eb1ead1ed72ec8f8dd92de7R2-R3) [[2]](diffhunk://#diff-830526ce9a9dc1e58c2fa4a045a56e6e5c42a80e6eb1ead1ed72ec8f8dd92de7R22-R49)
* Implements the service logic in `FacilitiesService.getGymSessions` to fetch sessions within the specified date range, with instructor population and sorting.
* Defines a Joi schema for validating `month` and `year` query parameters in `facility.validation.js`.
* Registers the new route `/gym/sessions` in `facility.route.js`, protected by authentication middleware.

**Supporting Changes**

* Updates model imports to ensure `GymSession` and related user models are available in the service and model files. [[1]](diffhunk://#diff-245159ff805ba1cdf6bfcb4e585e390c7adf85fd357005417aac660f22f4e0cdL1-R1) [[2]](diffhunk://#diff-d5c42ed3b5e495c41de57508781294205a69b7f8308604afe2888600e82c19c3R2)