### PR TITLE
feat(events): add edit workshop endpoint with validation for professors

### DIFF
--- a/server/src/features/events/event.controller.js
+++ b/server/src/features/events/event.controller.js
@@ -10,6 +10,7 @@ import {
   createBazaarSchema,
   updateBazaarSchema,
   updateConferenceSchema,
+  updateWorkshopSchema
 } from "./event.validation.js";
 
 //Write your code in this class!!!
@@ -328,6 +329,54 @@ export class EventsController {
       res.status(500).json({ message: "Error rejecting workshop", error });
     }
   }
+
+  /**
+   * Controller to handle editing a workshop.
+   */
+  async editWorkshop(req, res, next) {
+    try {
+      if (!req.user) {
+        throw new ApiError(401, "Unauthorized");
+      }
+
+      if (req.user.role !== "professor") {
+        throw new ApiError(
+          403,
+          "Forbidden: Only professors can edit workshops"
+        );
+      }
+      // Get the workshop ID from URL parameters
+      const { workshopId } = req.params;
+
+      // Validate the request body against the schema
+      const { error } = updateWorkshopSchema.validate(req.body);
+      if (error) {
+        throw new ApiError(400, error.details[0].message);
+      }
+
+      // Call the service to perform the update logic
+      const updatedWorkshop = await eventService.editWorkshop(
+        workshopId,
+        req.body,
+        req.user
+      );
+
+      // Send a successful response
+      return res
+        .status(200)
+        .json(
+          new ApiResponse(
+            200,
+            updatedWorkshop,
+            "Workshop updated successfully and is now pending re-approval"
+          )
+        );
+    } catch (err) {
+      // Pass errors to the central error handler
+      next(err);
+    }
+  }
+
   //Rana (to be deleted later)
   //Register for event (workshop/trip)
   async registerForEvent(req, res) {

--- a/server/src/features/events/event.route.js
+++ b/server/src/features/events/event.route.js
@@ -71,6 +71,14 @@ router.patch(
   eventsController.rejectWorkshop.bind(eventsController)
 );
 
+// Edit a workshop that needs revision
+router.patch(
+  "/workshops/:workshopId",
+  authMiddleware,
+  roleMiddleware(["professor"]),
+  eventsController.editWorkshop.bind(eventsController)
+);
+
 // POST /api/admin/trips
 router.post(
   "/admin/trips",

--- a/server/src/features/events/event.service.js
+++ b/server/src/features/events/event.service.js
@@ -145,6 +145,43 @@ export const createWorkshop = async (workshopData, professorId) => {
   return workshop;
 };
 
+/**
+ * Allows a professor to edit their own workshop if it needs revision.
+ * @param {string} workshopId - The ID of the workshop to edit.
+ * @param {object} updateData - The fields to update.
+ * @param {object} user - The authenticated professor user.
+ * @returns {Promise<Document>} The updated workshop document.
+ */
+export async function editWorkshop(workshopId, updateData, user) {
+  const workshop = await Event.findById(workshopId);
+  if (!workshop) {
+    throw new ApiError(404, "Workshop not found");
+  }
+
+  if (workshop.eventType !== "workshop") {
+    throw new ApiError(400, "This event is not a workshop");
+  }
+
+  if (workshop.createdBy.toString() !== user._id.toString()) {
+    throw new ApiError(403, "Forbidden: You can only edit your own workshops");
+  }
+
+  if (workshop.status !== "needs_revision") {
+    throw new ApiError(
+      403,
+      "Forbidden: Workshop can only be edited if its status is 'needs_revision'"
+    );
+  }
+
+  Object.assign(workshop, updateData);
+
+  workshop.status = "pending";
+
+  await workshop.save();
+
+  return workshop;
+}
+
 export const updateTripService = async (tripId, updateData, user) => {
   // 1. Fetch trip
   const trip = await Event.findById(tripId);

--- a/server/src/features/events/event.service.js
+++ b/server/src/features/events/event.service.js
@@ -166,10 +166,10 @@ export async function editWorkshop(workshopId, updateData, user) {
     throw new ApiError(403, "Forbidden: You can only edit your own workshops");
   }
 
-  if (workshop.status !== "needs_revision") {
+  if (workshop.status !== "pending" && workshop.status !== "needs_revision") {
     throw new ApiError(
       403,
-      "Forbidden: Workshop can only be edited if its status is 'needs_revision'"
+      "Forbidden: Workshop can only be edited if its status is 'pending' or 'needs_revision'"
     );
   }
 

--- a/server/src/features/events/event.validation.js
+++ b/server/src/features/events/event.validation.js
@@ -138,6 +138,36 @@ export const createWorkshopSchema = Joi.object({
     }),
 });
 
+export const updateWorkshopSchema = Joi.object({
+  name: Joi.string().trim().optional(),
+  description: Joi.string().optional(),
+  location: Joi.string().valid("GUC Cairo", "GUC Berlin").optional(),
+  startDate: Joi.date().optional(),
+  endDate: Joi.date().when('startDate', {
+    is: Joi.exist(),
+    then: Joi.date().greater(Joi.ref("startDate")),
+    otherwise: Joi.date().optional()
+  }),
+  registrationDeadline: Joi.date().when('startDate', {
+    is: Joi.exist(),
+    then: Joi.date().less(Joi.ref("startDate")),
+    otherwise: Joi.date().optional()
+  }),
+  capacity: Joi.number().integer().min(1).optional(),
+  agenda: Joi.string().optional(),
+  requiredBudget: Joi.number().positive().optional(),
+  fundingSource: Joi.string().valid("external", "guc").optional(),
+  extraResources: Joi.string().optional(),
+  faculty: Joi.string().optional(),
+  professors: Joi.array()
+    .items(Joi.string().hex().length(24))
+    .min(1)
+    .optional(),
+
+  price: Joi.forbidden(),
+  websiteUrl: Joi.forbidden(),
+}).min(1);
+
 export const updateTripSchema = Joi.object({
   name: Joi.string(),
   description: Joi.string(),


### PR DESCRIPTION
This pull request adds support for professors to edit their own workshops when revisions are required. It introduces a new endpoint, validation schema, controller method, and service logic to handle workshop editing, ensuring only authorized professors can update workshops with a status of "needs_revision". The changes are grouped as follows:

**Workshop Editing Feature:**

* Added `updateWorkshopSchema` to `event.validation.js` for validating workshop edit requests, ensuring only permitted fields can be updated and enforcing business rules on dates and forbidden fields.
* Implemented the `editWorkshop` service function in `event.service.js`, which checks workshop ownership, type, and status before applying updates and resetting the status to "pending".
* Created the `editWorkshop` controller method in `event.controller.js` to handle authorization, validation, and response formatting for workshop edits.
* Registered a new PATCH endpoint `/workshops/:workshopId` in `event.route.js`, protected by authentication and role middleware, to allow professors to submit workshop edits.

**Validation and Import Updates:**

* Imported `updateWorkshopSchema` in `event.controller.js` to enable request validation for the new edit functionality.