### PR TITLE
feat(applications): add admin/eventsOffice ability to update vendor application status

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -19,7 +19,8 @@
         "jsonwebtoken": "^9.0.2",
         "mongodb": "^6.20.0",
         "mongoose": "^8.4.0",
-        "nodemailer": "^7.0.9"
+        "nodemailer": "^7.0.9",
+        "resend": "^6.1.2"
       },
       "devDependencies": {
         "nodemon": "^3.1.0"
@@ -3328,6 +3329,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resend": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-6.1.2.tgz",
+      "integrity": "sha512-C9Q+YkRe57P8MQlkHG3yatSR/B6sqBGA06Ri2DveJfkz9Vm16182FC/iHB0K6IAfmqZ4yRrFebFw1EPuktLtSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@react-email/render": "*"
+      },
+      "peerDependenciesMeta": {
+        "@react-email/render": {
+          "optional": true
+        }
       }
     },
     "node_modules/retry": {

--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,8 @@
   "type": "module",
   "scripts": {
     "start": "node src/index.js",
-    "dev": "nodemon src/index.js"
+    "dev": "nodemon src/index.js",
+    "seed:pending": "node src/seed.js"
   },
   "keywords": [],
   "author": "",
@@ -22,17 +23,10 @@
     "jsonwebtoken": "^9.0.2",
     "mongodb": "^6.20.0",
     "mongoose": "^8.4.0",
-    "nodemailer": "^7.0.9"
+    "nodemailer": "^7.0.9",
+    "resend": "^6.1.2"
   },
   "devDependencies": {
     "nodemon": "^3.1.0"
-  },
-  "scripts": {
-  "start": "node src/index.js",
-  "dev": "nodemon src/index.js",
-  "seed:pending": "node src/seed.js"
+  }
 }
-
-  
-}
-

--- a/server/src/features/applications/application.controller.js
+++ b/server/src/features/applications/application.controller.js
@@ -45,4 +45,42 @@ export class ApplicationController {
       next(error);
     }
   }
+  async updateApplicationStatus(req, res, next) {
+  try {
+    const { applicationId } = req.params;
+    const { status } = req.body;
+
+    // Only allow 'accepted' or 'rejected'
+    if (!["accepted", "rejected"].includes(status)) {
+      return res.status(400).json({
+        success: false,
+        message: "Invalid status value. Must be 'accepted' or 'rejected'.",
+      });
+    }
+
+    const updatedApplication = await ApplicationService.updateApplicationStatus(
+      applicationId,
+      status
+    );
+
+    if (!updatedApplication) {
+      return res.status(404).json({
+        success: false,
+        message: "Application not found.",
+      });
+    }
+
+    res.status(200).json({
+      success: true,
+      message: `Application status updated to ${status}.`,
+      data: updatedApplication,
+    });
+  } catch (error) {
+    if (error.message === "Application not found") {
+      return res.status(404).json({ success: false, message: error.message });
+    }
+    next(error);
+  }
+}
+
 }

--- a/server/src/features/applications/application.model.js
+++ b/server/src/features/applications/application.model.js
@@ -1,4 +1,3 @@
-
 import mongoose from "mongoose";
 
 const applicationSchema = new mongoose.Schema(
@@ -57,7 +56,5 @@ const applicationSchema = new mongoose.Schema(
   }
 );
 
-
 const Application = mongoose.model("Application", applicationSchema);
 export default Application;
-

--- a/server/src/features/applications/application.route.js
+++ b/server/src/features/applications/application.route.js
@@ -25,4 +25,12 @@ router.get(
   validateQuery(getMyApplicationsSchema), // Use the new middleware here
   applicationController.getMyApplications.bind(applicationController)
 );
+// PATCH /api/admin/applications/:applicationId/status
+router.patch(
+  "/:applicationId/status",
+  authMiddleware,
+  role(["admin", "eventsOffice"]),
+  applicationController.updateApplicationStatus.bind(applicationController)
+);
+
 export default router;

--- a/server/src/features/applications/application.service.js
+++ b/server/src/features/applications/application.service.js
@@ -39,6 +39,24 @@ class ApplicationServiceClass {
 
     return applications;
   }
+  /**
+ * Updates the status of an application by its ID.
+ * @param {string} applicationId - The ID of the application.
+ * @param {string} status - The new status ("accepted" or "rejected").
+ * @returns {Promise<Document|null>} The updated application.
+ */
+async updateApplicationStatus(applicationId, status) {
+  const application = await Application.findById(applicationId);
+  if (!application) {
+    throw new Error("Application not found");
+  }
+
+  application.status = status;
+  await application.save();
+
+  return application;
+}
+
 }
 
 export const ApplicationService = new ApplicationServiceClass();


### PR DESCRIPTION
Added PATCH /api/admin/applications/:applicationId/status endpoint.

Allows Admin and Events Office to accept or reject vendor applications.

Validates status field (accepted or rejected) and returns updated application.

Role-based access control enforced (403 for unauthorized roles).

Tested successfully in Postman.