### PR TITLE
feat(events): add 'platform_booth' to eventType enum in event schema

### DIFF
--- a/server/src/features/events/event.model.js
+++ b/server/src/features/events/event.model.js
@@ -7,7 +7,7 @@ const eventSchema = new Schema(
     eventType: {
       type: String,
       required: true,
-      enum: ['bazaar', 'trip', 'workshop', 'conference']
+      enum: ['bazaar', 'trip', 'workshop', 'conference', 'platform_booth']
     },
     description: { type: String, required: true },
     location: { type: String, required: true },


### PR DESCRIPTION
This pull request makes a small update to the event schema by adding a new event type option. The change expands the allowed values for the `eventType` field.

* Added `'platform_booth'` to the list of allowed values for the `eventType` field in the `eventSchema` definition in `server/src/features/events/event.model.js`.