### PR TITLE
refactor(server): update default PORT to 4000 in server and routes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,7 +1,6 @@
 {
-
+  "name": "rest-express",
   "version": "1.0.0",
-  "name": "Eventy",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -3947,9 +3946,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001677",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001677.tgz",
-      "integrity": "sha512-fmfjsOlJUpMWu+mAAtZZZHz7UEwsUxIIvu1TJfO1HqFQvB/B+ii0xr9B5HpbZY/mC4XZ8SvjHJqtAY6pDPQEog==",
+      "version": "1.0.30001750",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001750.tgz",
+      "integrity": "sha512-cuom0g5sdX6rw00qOoLNSFCJ9/mYIsuSOA+yzpDw8eopiFqcVwQvZHqov0vmEighRxX++cfC0Vg1G+1Iy/mSpQ==",
       "dev": true,
       "funding": [
         {

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -2023,67 +2023,6 @@
         "uuid": "dist/bin/uuid"
       }
     },
-    "node_modules/gcp-metadata": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-5.3.0.tgz",
-      "integrity": "sha512-FNTkdNEnBdlqF2oatizolQqNANMrcqJt6AAYt99B3y1aLLC8Hc5IOBb+ZnnzllodEEf6xMBp6wRcBbc16fa65w==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "gaxios": "^5.0.0",
-        "json-bigint": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/gcp-metadata/node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/gcp-metadata/node_modules/gaxios": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-5.1.3.tgz",
-      "integrity": "sha512-95hVgBRgEIRQQQHIbnxBXeHbW4TqFk4ZDJW7wmVtvYar72FdhRIo1UGOLS2eRAKCPEdPBWu+M7+A33D9CdX9rA==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "extend": "^3.0.2",
-        "https-proxy-agent": "^5.0.0",
-        "is-stream": "^2.0.0",
-        "node-fetch": "^2.6.9"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/gcp-metadata/node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -2,7 +2,7 @@ import 'dotenv/config'; // Make sure this is at the very top
 import app from './app.js';
 import connectDB from './config/db.js';
 
-const PORT = process.env.PORT || 5000;
+const PORT = process.env.PORT || 4000;
 
 const startServer = async () => {
   // Connect to the database before starting the server

--- a/server/src/routes/index.js
+++ b/server/src/routes/index.js
@@ -5,7 +5,7 @@ import userRoutes from "../features/users/user.route.js";
 import eventRoutes from "../features/events/event.route.js";
 import applicationRoutes from "../features/applications/application.route.js";
 import facilityRoutes from "../features/facilities/facility.route.js";
-const PORT = process.env.PORT || 5000;
+const PORT = process.env.PORT || 4000;
 const router = express.Router();
 
 // Placeholder route to confirm the API is working


### PR DESCRIPTION
This pull request primarily makes configuration and dependency updates to the server. The most important changes are the removal of the `gcp-metadata` package and its related dependencies, and an update to the default server port from 5000 to 4000.

**Dependency updates:**

* Removed the `gcp-metadata` package and its nested dependencies (`agent-base`, `gaxios`, `https-proxy-agent`) from `package-lock.json`, cleaning up unused or unnecessary dependencies.

**Configuration changes:**

* Changed the default server port from `5000` to `4000` in both `server/src/index.js` and `server/src/routes/index.js` to standardize the port configuration. [[1]](diffhunk://#diff-ca1c659f55ca813ddb05ea5965e2e6c9a4a1d82a22f7067a2b34718cd4e83c4cL5-R5) [[2]](diffhunk://#diff-475aa6062062c0a7a00a6edd49daaa93787a162c9f69eed76048e82bd1267a2dL8-R8)