### PR TITLE
feat(events): fetch and display registered events with improved loading state

### DIFF
--- a/client/src/pages/MyEvents.tsx
+++ b/client/src/pages/MyEvents.tsx
@@ -28,6 +28,10 @@ export default function MyEvents() {
             Authorization: `Bearer ${getToken()}`,
           },
         });
+        if (!res.ok) {
+          setRegisteredEvents([]);
+          return;
+        }
         const data = await res.json();
         setRegisteredEvents(data.data || []);
       } catch (err) {

--- a/client/src/pages/MyEvents.tsx
+++ b/client/src/pages/MyEvents.tsx
@@ -1,61 +1,52 @@
+import { useEffect, useState } from "react";
 import { Heart, Calendar, MapPin, Clock } from "lucide-react";
 import Header from "@/components/Header";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import CategoryBadge from "@/components/CategoryBadge";
 
-//todo: remove mock functionality
-const registeredEvents = [
-  {
-    id: "1",
-    title: "AI & Machine Learning Workshop",
-    category: "academic" as const,
-    date: "March 15, 2024",
-    time: "2:00 PM - 5:00 PM",
-    location: "Engineering Building",
-    status: "upcoming",
-    image: "https://images.unsplash.com/photo-1591453089816-0fbb971b454c?w=400&auto=format&fit=crop",
-  },
-  {
-    id: "2",
-    title: "Spring Festival",
-    category: "cultural" as const,
-    date: "March 20, 2024",
-    time: "6:00 PM - 10:00 PM",
-    location: "Main Quadrangle",
-    status: "upcoming",
-    image: "https://images.unsplash.com/photo-1533174072545-7a4b6ad7a6c3?w=400&auto=format&fit=crop",
-  },
-];
-
-const favoriteEvents = [
-  {
-    id: "3",
-    title: "Career Fair 2024",
-    category: "career" as const,
-    date: "March 25, 2024",
-    time: "10:00 AM - 4:00 PM",
-    location: "Convention Center",
-    image: "https://images.unsplash.com/photo-1560439514-4e9645039924?w=400&auto=format&fit=crop",
-  },
-];
+// Helper to get token (adjust as needed)
+const getToken = () => localStorage.getItem("token");
 
 export default function MyEvents() {
+  const [registeredEvents, setRegisteredEvents] = useState<any[]>([]);
+  const [favoriteEvents, setFavoriteEvents] = useState<any[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchEvents = async () => {
+      setLoading(true);
+      try {
+        const res = await fetch("http://localhost:4000/api/events/me/events", {
+          headers: {
+            Authorization: `Bearer ${getToken()}`,
+          },
+        });
+        const data = await res.json();
+        setRegisteredEvents(data.data || []);
+      } catch (err) {
+        setRegisteredEvents([]);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchEvents();
+  }, []);
+
   const handleCancelRegistration = (eventId: string) => {
-    console.log("Cancel registration:", eventId);
+    // Implement cancel logic here
     alert("Registration cancelled. Amount will be refunded to your wallet.");
   };
 
   const handleRemoveFavorite = (eventId: string) => {
-    console.log("Remove from favorites:", eventId);
+    // Implement remove favorite logic here
   };
 
   return (
     <div className="min-h-screen bg-background">
       <Header />
-      
       <main className="max-w-7xl mx-auto px-4 md:px-6 py-8">
         <div className="mb-8">
           <h1 className="text-4xl font-bold mb-2">My Events</h1>
@@ -77,57 +68,73 @@ export default function MyEvents() {
           </TabsList>
 
           <TabsContent value="registered" className="space-y-4">
-            <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-              {registeredEvents.map((event) => (
-                <Card key={event.id} className="overflow-hidden" data-testid={`card-registered-${event.id}`}>
-                  <div className="relative aspect-[16/9] bg-muted">
-                    <img
-                      src={event.image}
-                      alt={event.title}
-                      className="w-full h-full object-cover"
-                    />
-                    <div className="absolute top-3 left-3">
-                      <CategoryBadge category={event.category} />
-                    </div>
-                  </div>
-                  <CardContent className="p-4 space-y-3">
-                    <h3 className="text-xl font-bold">{event.title}</h3>
-                    
-                    <div className="space-y-2 text-sm text-muted-foreground">
-                      <div className="flex items-center gap-1">
-                        <Calendar className="h-3 w-3" />
-                        {event.date}
-                      </div>
-                      <div className="flex items-center gap-1">
-                        <Clock className="h-3 w-3" />
-                        {event.time}
-                      </div>
-                      <div className="flex items-center gap-1">
-                        <MapPin className="h-3 w-3" />
-                        {event.location}
+            {loading ? (
+              <div>Loading...</div>
+            ) : (
+              <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+                {registeredEvents.map((event) => (
+                  <Card
+                    key={event.id || event._id}
+                    className="overflow-hidden"
+                    data-testid={`card-registered-${event.id || event._id}`}
+                  >
+                    <div className="relative aspect-[16/9] bg-muted">
+                      <img
+                        src={event.image || "/placeholder.jpg"}
+                        alt={event.title || event.name}
+                        className="w-full h-full object-cover"
+                      />
+                      <div className="absolute top-3 left-3">
+                        <CategoryBadge category={event.category} />
                       </div>
                     </div>
-
-                    <Badge className="bg-green-500 hover:bg-green-600">Registered</Badge>
-
-                    <Button
-                      variant="destructive"
-                      className="w-full"
-                      onClick={() => handleCancelRegistration(event.id)}
-                      data-testid={`button-cancel-${event.id}`}
-                    >
-                      Cancel Registration
-                    </Button>
-                  </CardContent>
-                </Card>
-              ))}
-            </div>
+                    <CardContent className="p-4 space-y-3">
+                      <h3 className="text-xl font-bold">
+                        {event.title || event.name}
+                      </h3>
+                      <div className="space-y-2 text-sm text-muted-foreground">
+                        <div className="flex items-center gap-1">
+                          <Calendar className="h-3 w-3" />
+                          {event.date || event.startDate}
+                        </div>
+                        <div className="flex items-center gap-1">
+                          <Clock className="h-3 w-3" />
+                          {event.time ||
+                            `${event.startTime || ""} - ${event.endTime || ""}`}
+                        </div>
+                        <div className="flex items-center gap-1">
+                          <MapPin className="h-3 w-3" />
+                          {event.location}
+                        </div>
+                      </div>
+                      <Badge className="bg-green-500 hover:bg-green-600">
+                        Registered
+                      </Badge>
+                      <Button
+                        variant="destructive"
+                        className="w-full"
+                        onClick={() =>
+                          handleCancelRegistration(event.id || event._id)
+                        }
+                        data-testid={`button-cancel-${event.id || event._id}`}
+                      >
+                        Cancel Registration
+                      </Button>
+                    </CardContent>
+                  </Card>
+                ))}
+              </div>
+            )}
           </TabsContent>
 
           <TabsContent value="favorites" className="space-y-4">
             <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
               {favoriteEvents.map((event) => (
-                <Card key={event.id} className="overflow-hidden" data-testid={`card-favorite-${event.id}`}>
+                <Card
+                  key={event.id}
+                  className="overflow-hidden"
+                  data-testid={`card-favorite-${event.id}`}
+                >
                   <div className="relative aspect-[16/9] bg-muted">
                     <img
                       src={event.image}
@@ -140,7 +147,7 @@ export default function MyEvents() {
                   </div>
                   <CardContent className="p-4 space-y-3">
                     <h3 className="text-xl font-bold">{event.title}</h3>
-                    
+
                     <div className="space-y-2 text-sm text-muted-foreground">
                       <div className="flex items-center gap-1">
                         <Calendar className="h-3 w-3" />
@@ -157,7 +164,10 @@ export default function MyEvents() {
                     </div>
 
                     <div className="flex gap-2">
-                      <Button className="flex-1" data-testid={`button-register-${event.id}`}>
+                      <Button
+                        className="flex-1"
+                        data-testid={`button-register-${event.id}`}
+                      >
                         Register
                       </Button>
                       <Button

--- a/client/src/pages/MyEvents.tsx
+++ b/client/src/pages/MyEvents.tsx
@@ -19,7 +19,11 @@ export default function MyEvents() {
     const fetchEvents = async () => {
       setLoading(true);
       try {
-        const res = await fetch("http://localhost:4000/api/events/me/events", {
+        const apiBaseUrl = process.env.REACT_APP_API_BASE_URL;
+        if (!apiBaseUrl) {
+          throw new Error("REACT_APP_API_BASE_URL environment variable is not set");
+        }
+        const res = await fetch(`${apiBaseUrl}/api/events/me/events`, {
           headers: {
             Authorization: `Bearer ${getToken()}`,
           },

--- a/client/src/pages/MyEvents.tsx
+++ b/client/src/pages/MyEvents.tsx
@@ -108,7 +108,13 @@ export default function MyEvents() {
                         <div className="flex items-center gap-1">
                           <Clock className="h-3 w-3" />
                           {event.time ||
-                            `${event.startTime || ""} - ${event.endTime || ""}`}
+                            (event.startTime && event.endTime
+                              ? `${event.startTime} - ${event.endTime}`
+                              : event.startTime
+                              ? event.startTime
+                              : event.endTime
+                              ? event.endTime
+                              : "Time not specified")}
                         </div>
                         <div className="flex items-center gap-1">
                           <MapPin className="h-3 w-3" />


### PR DESCRIPTION
This pull request updates the `MyEvents` page to fetch registered events dynamically from the backend API instead of using hardcoded mock data. It also improves the rendering logic to handle loading states and more robustly display event information, accommodating differences in API response fields.

**Dynamic event fetching and UI improvements:**

* Replaced hardcoded `registeredEvents` mock data with a `useEffect` hook that fetches the user's registered events from the backend API (`/api/events/me/events`), using a stored authentication token for authorization. Added loading state handling for better user experience.
* Updated the registered events tab to show a loading indicator while fetching data and to handle cases where event fields may differ (e.g., using `event.name` if `event.title` is missing, or `event._id` as a fallback for `event.id`).
* Improved event card rendering to display event details using fallback fields from the API response, ensuring compatibility with backend data structure changes.
* Cleaned up the code by removing unused imports and mock data, and ensured that event actions (such as cancel registration) are ready for future integration with backend logic.
* Minor UI consistency fixes, such as updating button and badge rendering for registered and favorite events.