### PR TITLE
refactor(events): replace professors array with single professor field in event schema

### DIFF
--- a/server/src/features/events/event.model.js
+++ b/server/src/features/events/event.model.js
@@ -82,15 +82,13 @@ const eventSchema = new Schema(
       return this.eventType === "workshop";
     },
   },
-  professors: [
-    {
+  professor:{
       type: mongoose.Schema.Types.ObjectId,
       ref: "User",
       required: function () {
         return this.eventType === "workshop";
       },
     },
-  ],
   websiteUrl: {
     type: String,
     required: function () {

--- a/server/src/features/events/event.service.js
+++ b/server/src/features/events/event.service.js
@@ -144,6 +144,7 @@ export const createWorkshop = async (workshopData, professorId) => {
   const workshop = await Event.create({
     ...workshopData,
     eventType: "workshop",
+    professor: professorId,
     createdBy: professorId,
     status: "pending",
   });
@@ -259,7 +260,7 @@ export const getUpcomingEventsService = async () => {
     status: "approved",
     startDate: { $gte: now },
   })
-    .populate("professors", "name email") // now Mongoose knows User schema
+    .populate("professor", "name email")
     .populate("createdBy", "name email")
     .lean();
 

--- a/server/src/features/events/event.validation.js
+++ b/server/src/features/events/event.validation.js
@@ -127,15 +127,14 @@ export const createWorkshopSchema = Joi.object({
     "string.base": "Faculty must be text",
   }),
 
-  professors: Joi.array()
-    .items(Joi.string().hex().length(24))
-    .min(1)
-    .required()
-    .messages({
-      "any.required": "At least one professor is required",
-      "array.min": "Professors list must contain at least one ID",
-      "string.hex": "Professor IDs must be valid ObjectIds",
-    }),
+  professor: Joi.string()
+  .hex()
+  .length(24)
+  .required()
+  .messages({
+    "any.required": "Professor ID is required",
+    "string.hex": "Professor ID must be a valid ObjectId",
+  }),
 });
 
 export const updateWorkshopSchema = Joi.object({
@@ -159,10 +158,7 @@ export const updateWorkshopSchema = Joi.object({
   fundingSource: Joi.string().valid("external", "guc").optional(),
   extraResources: Joi.string().optional(),
   faculty: Joi.string().optional(),
-  professors: Joi.array()
-    .items(Joi.string().hex().length(24))
-    .min(1)
-    .optional(),
+  professor: Joi.string().hex().length(24).optional(),
 
   price: Joi.forbidden(),
   websiteUrl: Joi.forbidden(),
@@ -249,6 +245,6 @@ export const updateBazaarSchema = Joi.object({
   requiredBudget: Joi.forbidden(),
   fundingSource: Joi.forbidden(),
   faculty: Joi.forbidden(),
-  professors: Joi.forbidden(),
+  professor: Joi.forbidden(),
   websiteUrl: Joi.forbidden(),
 });


### PR DESCRIPTION
This pull request refactors how professors are associated with workshop events. Instead of storing multiple professors in an array, each workshop now references a single professor using the `professor` field. This change affects the event model, validation schemas, service logic, and data population for upcoming events.

**Workshop professor association refactor:**

* Changed the `event.model.js` schema to use a single `professor` field (ObjectId) instead of an array of `professors` for workshops.
* Updated the event creation logic in `event.service.js` to set the `professor` field when creating a workshop.
* Modified the population logic in `getUpcomingEventsService` to use `professor` instead of `professors`.

**Validation schema updates:**

* Updated `createWorkshopSchema` and `updateWorkshopSchema` in `event.validation.js` to validate a single `professor` field instead of an array of `professors`. [[1]](diffhunk://#diff-aec9067a97fb785d81458539000a8a185af0b348a0d8191fe28ffa9ba9fd7353L130-R136) [[2]](diffhunk://#diff-aec9067a97fb785d81458539000a8a185af0b348a0d8191fe28ffa9ba9fd7353L162-R161)
* Changed `updateBazaarSchema` to forbid the `professor` field instead of `professors`.