### PR TITLE
feat(events): add endpoint route to retrieve events registered by the logged in user

### DIFF
--- a/server/src/features/events/event.route.js
+++ b/server/src/features/events/event.route.js
@@ -3,7 +3,6 @@ import { EventsController } from "./event.controller.js";
 import authMiddleware from ".././../middlewares/auth.middleware.js";
 import roleMiddleware from "../../middlewares/role.middleware.js";
 
-
 const router = express.Router();
 const eventsController = new EventsController();
 
@@ -116,14 +115,12 @@ router.patch(
   eventsController.updateConferenceController.bind(eventsController)
 );
 
-
 router.get(
   "/upcoming",
   authMiddleware,
   roleMiddleware(["vendor"]),
   eventsController.getUpcomingEvents.bind(eventsController)
 );
-
 
 // Search events (✅ new feature)
 router.get(
@@ -138,5 +135,13 @@ router.get(
     "admin",
   ]),
   eventsController.searchEvents.bind(eventsController)
+);
+
+// Get all events the logged-in user registered for
+router.get(
+  "/me/events",
+  authMiddleware,
+  roleMiddleware(["student", "staff", "ta", "professor"]),
+  eventsController.getMyEvents.bind(eventsController)
 );
 export default router;


### PR DESCRIPTION
This pull request adds a new API endpoint to allow logged-in users to retrieve all events they have registered for. It also includes minor cleanup in the `event.route.js` file.

New feature:

* Added a `GET /me/events` endpoint to return all events the currently authenticated user is registered for, accessible to users with the roles `student`, `staff`, `ta`, or `professor`.

Code cleanup:

* Removed extra blank lines for improved code readability in `event.route.js`. [[1]](diffhunk://#diff-a0987f8ea95787f087f61e3423f71546f1911a3370274fdda8fa202cc614a201L6) [[2]](diffhunk://#diff-a0987f8ea95787f087f61e3423f71546f1911a3370274fdda8fa202cc614a201L119-L127)