### PR TITLE
feat(notifications): add POST endpoint for notifications

### DIFF
--- a/server/src/features/notifications/notification.controller.js
+++ b/server/src/features/notifications/notification.controller.js
@@ -1,17 +1,39 @@
 import NotificationService from "./notification.service.js";
+import { createNotificationSchema } from "./notification.validation.js";
 
 class NotificationController {
   static async getAllNotificationsByUserId(req, res) {
     try {
-      // Get userId from the authenticated user (set by authMiddleware)
       const userId = req.user && (req.user.id || req.user._id);
       if (!userId) {
-        return res.status(401).json({ success: false, message: "Unauthorized: user id not found" });
+        return res
+          .status(401)
+          .json({ success: false, message: "Unauthorized: user id not found" });
       }
       const notifications = await NotificationService.getNotificationsByUserId(
         userId
       );
       res.json({ success: true, data: notifications });
+    } catch (err) {
+      res
+        .status(500)
+        .json({ success: false, message: "Server error", error: err.message });
+    }
+  }
+
+  static async createNotification(req, res) {
+    try {
+      const { error, value } = createNotificationSchema.validate(req.body);
+      if (error) {
+        return res
+          .status(400)
+          .json({ success: false, message: error.details[0].message });
+      }
+
+      // Create a single notification with all recipients
+      const notification = await NotificationService.createNotification(value);
+
+      res.status(201).json({ success: true, data: notification });
     } catch (err) {
       res
         .status(500)

--- a/server/src/features/notifications/notification.model.js
+++ b/server/src/features/notifications/notification.model.js
@@ -4,11 +4,13 @@ const { Schema } = mongoose;
 
 const notificationSchema = new Schema(
   {
-    recipient: {
-      type: Schema.Types.ObjectId,
-      ref: "User",
-      required: true,
-    },
+    recipients: [
+      {
+        type: Schema.Types.ObjectId,
+        ref: "User",
+        required: true,
+      }
+    ],
     message: {
       type: String,
       required: true,

--- a/server/src/features/notifications/notification.route.js
+++ b/server/src/features/notifications/notification.route.js
@@ -24,4 +24,12 @@ router.get(
   NotificationController.getAllNotificationsByUserId
 );
 
+// POST /api/notifications
+router.post(
+  "/",
+  authMiddleware,
+  roleMiddleware(allRoles),
+  NotificationController.createNotification
+);
+
 export default router;

--- a/server/src/features/notifications/notification.service.js
+++ b/server/src/features/notifications/notification.service.js
@@ -1,8 +1,24 @@
 import Notification from "./notification.model.js";
 
 class NotificationService {
+  /**
+   * Get all notifications where the user is a recipient.
+   * @param {string} userId - The user's ObjectId as a string.
+   * @returns {Promise<Array>} Array of notification documents.
+   */
   static async getNotificationsByUserId(userId) {
-    return Notification.find({ recipient: userId }).sort({ createdAt: -1 });
+    return Notification.find({ recipients: { $in: [userId] } }).sort({
+      createdAt: -1,
+    });
+  }
+
+  /**
+   * Create a new notification document.
+   * @param {Object} data - Notification data (should include recipients array).
+   * @returns {Promise<Object>} The created notification document.
+   */
+  static async createNotification(data) {
+    return Notification.create(data);
   }
 }
 

--- a/server/src/features/notifications/notification.validation.js
+++ b/server/src/features/notifications/notification.validation.js
@@ -1,0 +1,14 @@
+import Joi from "joi";
+
+export const createNotificationSchema = Joi.object({
+  title: Joi.string().max(255).required(),
+  message: Joi.string().max(1000).required(),
+  type: Joi.string().max(50).default("info"),
+  recipients: Joi.array()
+    .items(Joi.string().hex().length(24))
+    .min(1)
+    .required(),
+  link: Joi.string().uri().allow(null, "").default(null),
+  isRead: Joi.boolean().default(false),
+  deletedAt: Joi.date().allow(null).default(null),
+});


### PR DESCRIPTION
This pull request adds support for creating notifications with multiple recipients and introduces input validation for notification creation. The changes include updates to the notification model, controller, service, route, and the addition of a validation schema.

**Notification model and service updates:**

* Changed the notification model to use a `recipients` array (instead of a single `recipient` field) to allow notifications to be sent to multiple users.
* Updated the notification service to query notifications where the user is included in the `recipients` array, and added a method to create notifications.

**API and validation enhancements:**

* Added a `createNotification` controller method, which validates request data using a new Joi schema before creating a notification. [[1]](diffhunk://#diff-319a24a4b710497ee38594d5e8a3e035cc8776c35b3b0c888b5ae0aaa45af7e5R23-R42) [[2]](diffhunk://#diff-8a7e5b019d027cb1e86f8e70b6e69a8bbd3be225039cf6885e5d805f92040b47R1-R14)
* Introduced a POST `/api/notifications` endpoint, protected by authentication and role middleware, to allow creation of notifications.

**Other improvements:**

* Improved error handling and response formatting in the notification controller.