### PR TITLE
feat(notifications): add patch endpoint for notifications

### DIFF
--- a/server/src/features/notifications/notification.controller.js
+++ b/server/src/features/notifications/notification.controller.js
@@ -1,5 +1,8 @@
 import NotificationService from "./notification.service.js";
-import { createNotificationSchema } from "./notification.validation.js";
+import {
+  createNotificationSchema,
+  updateNotificationSchema,
+} from "./notification.validation.js";
 
 class NotificationController {
   static async getAllNotificationsByUserId(req, res) {
@@ -34,6 +37,32 @@ class NotificationController {
       const notification = await NotificationService.createNotification(value);
 
       res.status(201).json({ success: true, data: notification });
+    } catch (err) {
+      res
+        .status(500)
+        .json({ success: false, message: "Server error", error: err.message });
+    }
+  }
+
+  static async updateNotification(req, res) {
+    try {
+      const { error, value } = updateNotificationSchema.validate(req.body);
+      if (error) {
+        return res
+          .status(400)
+          .json({ success: false, message: error.details[0].message });
+      }
+      const notificationId = req.params.id;
+      const updated = await NotificationService.updateNotification(
+        notificationId,
+        value
+      );
+      if (!updated) {
+        return res
+          .status(404)
+          .json({ success: false, message: "Notification not found" });
+      }
+      res.json({ success: true, data: updated });
     } catch (err) {
       res
         .status(500)

--- a/server/src/features/notifications/notification.route.js
+++ b/server/src/features/notifications/notification.route.js
@@ -32,4 +32,12 @@ router.post(
   NotificationController.createNotification
 );
 
+// PATCH /api/notifications/:id
+router.patch(
+  "/:id",
+  authMiddleware,
+  roleMiddleware(allRoles),
+  NotificationController.updateNotification
+);
+
 export default router;

--- a/server/src/features/notifications/notification.service.js
+++ b/server/src/features/notifications/notification.service.js
@@ -20,6 +20,18 @@ class NotificationService {
   static async createNotification(data) {
     return Notification.create(data);
   }
+
+  /**
+   * Update a notification by its ID.
+   * @param {string} notificationId
+   * @param {Object} updateData
+   * @returns {Promise<Object|null>}
+   */
+  static async updateNotification(notificationId, updateData) {
+    return Notification.findByIdAndUpdate(notificationId, updateData, {
+      new: true,
+    });
+  }
 }
 
 export default NotificationService;

--- a/server/src/features/notifications/notification.validation.js
+++ b/server/src/features/notifications/notification.validation.js
@@ -12,3 +12,13 @@ export const createNotificationSchema = Joi.object({
   isRead: Joi.boolean().default(false),
   deletedAt: Joi.date().allow(null).default(null),
 });
+
+export const updateNotificationSchema = Joi.object({
+  title: Joi.string().max(255),
+  message: Joi.string().max(1000),
+  type: Joi.string().max(50),
+  recipients: Joi.array().items(Joi.string().hex().length(24)).min(1),
+  link: Joi.string().uri().allow(null, ""),
+  isRead: Joi.boolean(),
+  deletedAt: Joi.date().allow(null),
+});


### PR DESCRIPTION
This pull request adds support for updating notifications in the notification system. It introduces a new API endpoint for updating notifications, including schema validation, controller logic, and service method implementation. The changes are grouped by API & routing, validation, controller logic, and service logic.

**API & Routing:**

* Added a new `PATCH /api/notifications/:id` endpoint to the router, which allows authorized users to update notifications.

**Validation:**

* Introduced `updateNotificationSchema` in `notification.validation.js` to validate the fields allowed when updating a notification.
* Updated imports in `notification.controller.js` to include the new schema.

**Controller Logic:**

* Added `updateNotification` method in `NotificationController` to handle validation, call the service layer, and return appropriate responses for update requests.

**Service Logic:**

* Implemented `updateNotification` method in `NotificationService` to update a notification by its ID using Mongoose's `findByIdAndUpdate`.