### PR TITLE
feat(notifications): add delete endpoint for notifications

### DIFF
--- a/server/src/features/notifications/notification.controller.js
+++ b/server/src/features/notifications/notification.controller.js
@@ -69,6 +69,26 @@ class NotificationController {
         .json({ success: false, message: "Server error", error: err.message });
     }
   }
+
+  // Soft delete: set deletedAt to now
+  static async deleteNotification(req, res) {
+    try {
+      const notificationId = req.params.id;
+      const deleted = await NotificationService.softDeleteNotification(
+        notificationId
+      );
+      if (!deleted) {
+        return res
+          .status(404)
+          .json({ success: false, message: "Notification not found" });
+      }
+      res.json({ success: true, data: deleted });
+    } catch (err) {
+      res
+        .status(500)
+        .json({ success: false, message: "Server error", error: err.message });
+    }
+  }
 }
 
 export default NotificationController;

--- a/server/src/features/notifications/notification.route.js
+++ b/server/src/features/notifications/notification.route.js
@@ -40,4 +40,12 @@ router.patch(
   NotificationController.updateNotification
 );
 
+// DELETE /api/notifications/:id (soft delete)
+router.delete(
+  "/:id",
+  authMiddleware,
+  roleMiddleware(allRoles),
+  NotificationController.deleteNotification
+);
+
 export default router;

--- a/server/src/features/notifications/notification.service.js
+++ b/server/src/features/notifications/notification.service.js
@@ -7,7 +7,10 @@ class NotificationService {
    * @returns {Promise<Array>} Array of notification documents.
    */
   static async getNotificationsByUserId(userId) {
-    return Notification.find({ recipients: { $in: [userId] } }).sort({
+    return Notification.find({
+      recipients: { $in: [userId] },
+      deletedAt: null,
+    }).sort({
       createdAt: -1,
     });
   }
@@ -31,6 +34,19 @@ class NotificationService {
     return Notification.findByIdAndUpdate(notificationId, updateData, {
       new: true,
     });
+  }
+
+  /**
+   * Soft delete a notification by setting deletedAt to now.
+   * @param {string} notificationId
+   * @returns {Promise<Object|null>}
+   */
+  static async softDeleteNotification(notificationId) {
+    return Notification.findByIdAndUpdate(
+      notificationId,
+      { deletedAt: new Date() },
+      { new: true }
+    );
   }
 }
 


### PR DESCRIPTION
This pull request adds soft delete functionality to the notifications feature, allowing notifications to be marked as deleted (by setting a `deletedAt` timestamp) instead of being permanently removed. It also ensures that soft-deleted notifications are not returned when fetching notifications for a user.

**Soft delete implementation:**

* Added a new `softDeleteNotification` method to `NotificationService` that sets the `deletedAt` field to the current date for a given notification, instead of removing it from the database.
* Introduced a new `deleteNotification` controller method in `NotificationController` to handle the soft delete operation and return appropriate responses.
* Added a new DELETE route (`DELETE /api/notifications/:id`) in `notification.route.js` to expose the soft delete functionality via the API, with authentication and role checks.

**Filtering out soft-deleted notifications:**

* Updated the `getNotificationsByUserId` method in `NotificationService` to exclude notifications where `deletedAt` is set, ensuring users only see active notifications.