### PR TITLE
Refactor(Events): make view bazaar list use getEvents instead of getupcoming

### DIFF
--- a/client/src/lib/bazaarApi.ts
+++ b/client/src/lib/bazaarApi.ts
@@ -56,6 +56,31 @@ class BazaarApiService {
     };
   }
 
+  async getEvents(type?: string): Promise<Bazaar[]> {
+    try {
+      const params = new URLSearchParams();
+      if (type) {
+        params.append("type", type);
+      }
+      
+      const response = await fetch(`${API_BASE_URL}/api/events?${params.toString()}`, {
+        method: "GET",
+        headers: this.getAuthHeaders(),
+        credentials: "include",
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+
+      const apiResponse: ApiResponse<Bazaar[]> = await response.json();
+      return apiResponse.data;
+    } catch (error) {
+      console.error("Error fetching events:", error);
+      throw error;
+    }
+  }
+
   async getUpcomingBazaars(): Promise<Bazaar[]> {
     try {
       const response = await fetch(`${API_BASE_URL}/api/events/upcoming`, {

--- a/client/src/pages/VendorDashboard.tsx
+++ b/client/src/pages/VendorDashboard.tsx
@@ -26,7 +26,7 @@ export default function VendorDashboard() {
     try {
       setLoading(true);
       setError(null);
-      const bazaars = await bazaarApiService.getUpcomingBazaars();
+      const bazaars = await bazaarApiService.getEvents("bazaar");
       setUpcomingBazaars(bazaars);
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : "Failed to fetch bazaars";


### PR DESCRIPTION
Update Vendor Dashboard to use /api/events?type=bazaar endpoint
**Changes Made:**
Added getEvents method to bazaarApi.ts that calls /api/events?type=bazaar endpoint
Updated VendorDashboard.tsx to use getEvents("bazaar") instead of getUpcomingBazaars()
Maintained backward compatibility by keeping the old getUpcomingBazaars method