### PR TITLE
refactor(facilities): simplify gym session instructor to string field

### DIFF
--- a/server/src/features/facilities/facility.model.js
+++ b/server/src/features/facilities/facility.model.js
@@ -29,8 +29,7 @@ const gymSessionSchema = new mongoose.Schema(
       required: true,
     },
     instructor: {
-      type: mongoose.Schema.Types.ObjectId,
-      ref: "User", // trainer/instructor
+      type: String, // instructor name
       required: true,
     },
 

--- a/server/src/features/facilities/facility.service.js
+++ b/server/src/features/facilities/facility.service.js
@@ -83,7 +83,6 @@ async getCourtSchedules() {
       date: { $gte: startOfMonth, $lte: endOfMonth },
       deletedAt: null,
     })
-      .populate("instructor", "name email role")
       .sort({ date: 1, startTime: 1 });
 
     return sessions;
@@ -95,14 +94,14 @@ async getCourtSchedules() {
    * @param {Object} user - Authenticated user
    */
   async createGymSession(data) {
-  const { date, time, duration, type, instructorId, maxParticipants } = data;
+  const { date, time, duration, type, instructor, maxParticipants } = data;
 
   const newSession = new GymSession({
     date,
     startTime: time,
     durationMinutes: duration,
     type,
-    instructor: instructorId,
+    instructor: instructor,
     maxParticipants: maxParticipants
   });
 

--- a/server/src/features/facilities/facility.validation.js
+++ b/server/src/features/facilities/facility.validation.js
@@ -54,17 +54,14 @@ export const createGymSessionSchema = Joi.object({
         "Invalid type. Must be one of yoga, pilates, aerobics, zumba, cross_circuit, or kick_boxing",
     }),
 
-  instructorId: Joi.string()
-    .custom((value, helpers) => {
-      if (!mongoose.Types.ObjectId.isValid(value)) {
-        return helpers.error("any.invalid");
-      }
-      return value;
-    })
+  instructor: Joi.string()
+    .min(2)
+    .max(100)
     .required()
     .messages({
-      "any.required": "Instructor ID is required",
-      "any.invalid": "Instructor ID must be a valid ObjectId",
+      "any.required": "Instructor name is required",
+      "string.min": "Instructor name must be at least 2 characters",
+      "string.max": "Instructor name cannot exceed 100 characters",
     }),
 
   maxParticipants: Joi.number()


### PR DESCRIPTION
This pull request updates how gym session instructors are represented and validated in the backend. Instead of using a reference to a user ID, the system now stores and validates the instructor's name directly as a string. This simplifies the data model and related service logic.

**Schema and Model Changes:**

* Changed the `instructor` field in the `gymSessionSchema` (`facility.model.js`) from a referenced `User` ObjectId to a simple string for the instructor's name.

**Service Logic Updates:**

* Removed the `.populate("instructor", "name email role")` call from `getCourtSchedules()` since the instructor is now stored as a string, not a reference.
* Updated `createGymSession()` to accept and store the instructor's name directly, replacing the previous use of `instructorId`.

**Validation Adjustments:**

* Modified the Joi validation schema in `facility.validation.js` to validate the instructor's name as a string (with length constraints), instead of validating an ObjectId.