### PR TITLE
fix(events): use user ID from request for event creation

### DIFF
--- a/server/src/features/events/event.controller.js
+++ b/server/src/features/events/event.controller.js
@@ -277,9 +277,10 @@ export class EventsController {
         );
       }
 
+      const userId = req.user._id || req.user.id;
       const events = await eventService.getEvents({
         eventType: "workshop",
-        createdBy: req.user._id,
+        createdBy: userId,
       });
 
       return res


### PR DESCRIPTION
This pull request makes a small but important update to the `EventsController` to improve how the user ID is retrieved when fetching events. The change ensures compatibility with different user object structures by checking both `_id` and `id` properties.

- Updated user ID retrieval logic in `EventsController` to use either `req.user._id` or `req.user.id` when querying for events, increasing robustness to user object variations.