### PR TITLE
feat(events): include companyName in event vendor details

### DIFF
--- a/server/src/features/events/event.service.js
+++ b/server/src/features/events/event.service.js
@@ -281,7 +281,7 @@ export const getUpcomingEventsService = async (includeVendors = false) => {
     deletedAt: null,
   })
     .populate("professors", "name email") // now Mongoose knows User schema
-    .populate("createdBy", "name email")
+    .populate("createdBy", "name email companyName")
     .lean();
 
   return events;
@@ -306,7 +306,7 @@ export const getUpcomingEventsWithVendors = async () => {
       const applications = await Application.find({ event: event._id })
         .populate({
           path: "createdBy",
-          select: "firstName lastName name email role", // support both schemas
+          select: "firstName lastName name email role companyName", // include companyName for vendors
         })
         .lean();
 
@@ -316,10 +316,15 @@ export const getUpcomingEventsWithVendors = async () => {
           const vendor = app.createdBy;
           if (!vendor) return null;
 
-          // Determine vendor name (handle both name or firstName+lastName)
-          const vendorName = vendor.name
-            ? vendor.name
-            : `${vendor.firstName || ""} ${vendor.lastName || ""}`.trim();
+          // Determine vendor name - prioritize companyName for vendors, fallback to name or firstName+lastName
+          let vendorName;
+          if (vendor.role === "vendor" && vendor.companyName) {
+            vendorName = vendor.companyName;
+          } else if (vendor.name) {
+            vendorName = vendor.name;
+          } else {
+            vendorName = `${vendor.firstName || ""} ${vendor.lastName || ""}`.trim();
+          }
 
           return {
             id: vendor._id,


### PR DESCRIPTION
This pull request enhances how vendor information is handled and displayed in upcoming events by including the `companyName` field for vendors and updating how vendor names are determined. The main focus is to ensure that vendor company names are prioritized and available wherever relevant.

Vendor information improvements:

* Updated `.populate()` calls in both `getUpcomingEventsService` and `getUpcomingEventsWithVendors` to include the `companyName` field for the `createdBy` user, ensuring that this information is available for both events and vendor applications. [[1]](diffhunk://#diff-e35439bc57d1007e3a9e6f23050c660fdd63cd2e32b872584c2160433d4847abL284-R284) [[2]](diffhunk://#diff-e35439bc57d1007e3a9e6f23050c660fdd63cd2e32b872584c2160433d4847abL309-R309)
* Refactored the logic for determining a vendor's display name in `getUpcomingEventsWithVendors` to prioritize `companyName` for vendors, falling back to `name`, and then to a combination of `firstName` and `lastName` if necessary.