### PR TITLE
fix(events): update fetch URL for pending workshops to include all workshops

### DIFF
--- a/client/src/pages/EventsOfficeDashboard.tsx
+++ b/client/src/pages/EventsOfficeDashboard.tsx
@@ -58,7 +58,7 @@ export default function EventsOfficeDashboard() {
   const fetchPendingWorkshops = async () => {
     try {
       const token = localStorage.getItem("token");
-      const res = await fetch(`${API_BASE_URL}/api/events/workshops`, {
+      const res = await fetch(`${API_BASE_URL}/api/events/allworkshops`, {
         headers: {
           "Content-Type": "application/json",
           ...(token ? { Authorization: `Bearer ${token}` } : {}),


### PR DESCRIPTION
This pull request makes a small but important update to the API endpoint used for fetching workshop data in the `EventsOfficeDashboard` component.

- Changed the fetch URL in the `fetchPendingWorkshops` function from `/api/events/workshops` to `/api/events/allworkshops` in `EventsOfficeDashboard.tsx` to ensure the correct set of workshops is retrieved.