### PR TITLE
feat: enhance search performance by adding indexes to event and user schemas

### DIFF
--- a/server/src/features/events/event.model.js
+++ b/server/src/features/events/event.model.js
@@ -103,6 +103,18 @@ const eventSchema = new Schema(
   { timestamps: true }
 );
 
+// Add indexes for search performance
+eventSchema.index({ name: 1 }); // Index for event name search
+eventSchema.index({ eventType: 1 }); // Index for event type search
+eventSchema.index({ status: 1 }); // Index for status filtering
+eventSchema.index({ startDate: 1 }); // Index for date filtering
+eventSchema.index({ deletedAt: 1 }); // Index for soft delete filtering
+eventSchema.index({ createdBy: 1 }); // Index for createdBy lookup
+eventSchema.index({ professors: 1 }); // Index for professors array lookup
+
+// Compound indexes for common query patterns
+eventSchema.index({ status: 1, startDate: 1, deletedAt: 1 }); // For upcoming events query
+eventSchema.index({ name: 'text', description: 'text' }); // Text index for name and description search
+
 
 export const Event = mongoose.model('Event', eventSchema);
-

--- a/server/src/features/users/user.model.js
+++ b/server/src/features/users/user.model.js
@@ -80,6 +80,12 @@ const userSchema = new mongoose.Schema(
   { timestamps: true }
 );
 
+// Add indexes for search performance
+userSchema.index({ firstName: 1 }); // Index for firstName search
+userSchema.index({ lastName: 1 }); // Index for lastName search
+userSchema.index({ firstName: 1, lastName: 1 }); // Compound index for full name search
+userSchema.index({ role: 1 }); // Index for role filtering
+
 userSchema.methods.comparePassword = async function (password) {
   return bcrypt.compare(password, this.password);
 };


### PR DESCRIPTION
This pull request enhances the performance of database queries related to events and users by adding several indexes to the Mongoose schemas. These indexes are designed to speed up common search and filtering operations, especially for large datasets.

**Database performance improvements:**

* Added single-field indexes to the `eventSchema` for fields such as `name`, `eventType`, `status`, `startDate`, `deletedAt`, `createdBy`, and `professors` to improve search and filtering efficiency.
* Introduced compound indexes in the `eventSchema` for common query patterns, including a compound index on `{ status, startDate, deletedAt }` for upcoming events queries, and a text index on `name` and `description` for full-text search.
* Added single-field indexes to the `userSchema` for `firstName`, `lastName`, and `role` to optimize user search and filtering.
* Added a compound index on `{ firstName, lastName }` in the `userSchema` to speed up full name searches.…schemas