### PR TITLE
Feat/add role based dashboard redirection after login

### DIFF
--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -55,6 +55,8 @@ export default function Login() {
           setLocation("/vendor/dashboard")
         } else if (role === "events_office") {
           setLocation("/events-office/dashboard")
+        } else if (role === "admin") {
+          setLocation("/admin")
         } else if (role === "staff" || role === "ta") {
           setLocation("/staff-ta")
         } else if (role === "professor") {

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -50,11 +50,14 @@ export default function Login() {
       const role = (data.user?.role ?? data.role ?? "").toLowerCase()
 
       setTimeout(() => {
+        // Prefer the normalized `role` variable for comparisons
         if (role === "vendor") {
           setLocation("/vendor/dashboard")
-        } else if (data.user.role === "staff" || data.user.role === "ta") {
+        } else if (role === "events_office") {
+          setLocation("/events-office/dashboard")
+        } else if (role === "staff" || role === "ta") {
           setLocation("/staff-ta")
-        } else if (data.user.role === "professor") {
+        } else if (role === "professor") {
           setLocation("/professor")
         } else {
           setLocation("/")


### PR DESCRIPTION
This pull request enhances the login redirection logic to better handle user roles and ensure users are directed to the correct dashboard based on their role. The role comparison is now normalized and additional roles are supported.

Improvements to login redirection:

* The `role` variable is now consistently normalized and used for all role comparisons, improving maintainability and reducing potential bugs.
* Added support for new roles: users with the `events_office` role are redirected to `/events-office/dashboard`, and users with the `admin` role are redirected to `/admin`.
* Updated the logic to use the normalized `role` variable for all existing role checks (such as `staff`, `ta`, and `professor`), ensuring consistent behavior.