### PR TITLE
feat(student-header): replace user icon button with profile menu in StudentHeader

### DIFF
--- a/client/src/components/StudentHeader.tsx
+++ b/client/src/components/StudentHeader.tsx
@@ -2,6 +2,7 @@ import { Bell, User, Home, Calendar, Dumbbell } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import ThemeToggle from "./ThemeToggle";
 import Logo from "./Logo";
+import ProfileMenu from "./ProfileMenu";
 import { useLocation } from "wouter";
 
 interface StudentHeaderProps {
@@ -24,9 +25,7 @@ export default function StudentHeader({ homeHref = "/" }: StudentHeaderProps) {
               <Bell className="h-5 w-5" />
             </Button>
             <ThemeToggle />
-            <Button variant="ghost" size="icon" data-testid="button-profile">
-              <User className="h-5 w-5" />
-            </Button>
+            <ProfileMenu />
           </div>
         </div>
 


### PR DESCRIPTION
This pull request updates the `StudentHeader` component to improve how the user profile menu is displayed. Instead of a simple icon button, the header now uses the new `ProfileMenu` component, which likely provides a more complete user profile experience.

**Header UI improvements:**

* Replaced the profile icon `Button` with the new `ProfileMenu` component in `StudentHeader`, enhancing the user profile interaction.
* Added the `ProfileMenu` import to `StudentHeader.tsx`.