### PR TITLE
feat(event-search): enhance search functionality by adding partial matching

### DIFF
--- a/server/src/features/events/event.service.js
+++ b/server/src/features/events/event.service.js
@@ -385,6 +385,11 @@ export const searchEvents = async ({ name, type }) => {
       $or: [
         { firstName: { $regex: name, $options: "i" } },
         { lastName: { $regex: name, $options: "i" } },
+        // Add variations with spaces for partial matching
+        { firstName: { $regex: `${name} `, $options: "i" } }, // "firstName "
+        { firstName: { $regex: ` ${name}`, $options: "i" } }, // " firstName"
+        { lastName: { $regex: `${name} `, $options: "i" } }, // "lastName "
+        { lastName: { $regex: ` ${name}`, $options: "i" } }, // " lastName"
       ],
     };
 
@@ -424,6 +429,11 @@ export const searchEvents = async ({ name, type }) => {
         $or: [
           { firstName: { $regex: name, $options: "i" } },
           { lastName: { $regex: name, $options: "i" } },
+          // Add variations with spaces for partial matching
+          { firstName: { $regex: `${name} `, $options: "i" } }, // "firstName "
+          { firstName: { $regex: ` ${name}`, $options: "i" } }, // " firstName"
+          { lastName: { $regex: `${name} `, $options: "i" } }, // "lastName "
+          { lastName: { $regex: ` ${name}`, $options: "i" } }, // " lastName"
         ],
       };
 


### PR DESCRIPTION

This pull request enhances the name search functionality in the `searchEvents` service by expanding how names are matched, making partial and space-separated matches more flexible and user-friendly.

Improvements to search matching:

* Updated the `$or` query in `searchEvents` to include additional regular expressions that match names with leading or trailing spaces, improving partial match accuracy for both `firstName` and `lastName` fields. [[1]](diffhunk://#diff-e35439bc57d1007e3a9e6f23050c660fdd63cd2e32b872584c2160433d4847abR388-R392) [[2]](diffhunk://#diff-e35439bc57d1007e3a9e6f23050c660fdd63cd2e32b872584c2160433d4847abR432-R436)