### PR TITLE
fix: update attendees count calculation to handle array of attendees

### DIFF
--- a/client/src/pages/AdminDashboardPage.tsx
+++ b/client/src/pages/AdminDashboardPage.tsx
@@ -236,7 +236,7 @@ export default function AdminDashboardPage() {
                             }) : "TBA"}
                             time={e.startDate ? new Date(e.startDate).toLocaleTimeString("en-US", { hour: "2-digit", minute: "2-digit", hour12: true }) : "TBA"}
                             location={e.location || "Unknown location"}
-                            attendees={e.attendeesCount || 0}
+                            attendees={Array.isArray(e.attendees) ? e.attendees.length : (e.attendeesCount || 0)}
                             image={e.bannerImage || e.image || getEventImage(e.eventType, e.name)}
                             description={e.description}
                             startDate={e.startDate}

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -151,7 +151,7 @@ export default function Dashboard() {
                         }) : "TBA"}
                         time={event.startDate ? new Date(event.startDate).toLocaleTimeString("en-US", { hour: "2-digit", minute: "2-digit", hour12: true }) : "TBA"}
                         location={event.location || "Unknown location"}
-                        attendees={event.attendeesCount || 0}
+                        attendees={Array.isArray(event.attendees) ? event.attendees.length : (event.attendeesCount || 0)}
                         vendors={event.vendors || []}
                         onRegister={() => console.log("Register:", event.name)}
                         onSave={() => console.log("Save:", event.name)}

--- a/client/src/pages/EventsOfficeDashboard.tsx
+++ b/client/src/pages/EventsOfficeDashboard.tsx
@@ -401,7 +401,7 @@ export default function EventsOfficeDashboard() {
                           })
                         : "TBA"}
                       location={event.location || "Unknown location"}
-                      attendees={event.attendeesCount || 0}
+                      attendees={Array.isArray(event.attendees) ? event.attendees.length : (event.attendeesCount || 0)}
                       image={event.bannerImage || event.image || getEventImage(event.eventType, event.name)}
                       description={event.description}
                       startDate={event.startDate}

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -82,7 +82,7 @@ export default function Home() {
                 })
               : "TBA"}
             location={events[0].location || "Unknown location"}
-            attendees={events[0].attendeesCount || 0}
+            attendees={Array.isArray(events[0].attendees) ? events[0].attendees.length : (events[0].attendeesCount || 0)}
             image={events[0].image || getEventImage(events[0].eventType, events[0].name)}
             description={
               events[0].description ||
@@ -147,7 +147,7 @@ export default function Home() {
                           })
                         : "TBA"}
                       location={event.location || "Unknown location"}
-                      attendees={event.attendeesCount || 0}
+                      attendees={Array.isArray(event.attendees) ? event.attendees.length : (event.attendeesCount || 0)}
                       image={event.bannerImage || event.image}
                       description={event.description}
                       startDate={event.startDate}

--- a/client/src/pages/ProfessorDashboard.tsx
+++ b/client/src/pages/ProfessorDashboard.tsx
@@ -256,7 +256,7 @@ export default function ProfessorDashboard() {
                       hour12: true,
                     }) : "TBA"}
                     location={event.location || "Unknown location"}
-                    attendees={event.attendeesCount || 0}
+                    attendees={Array.isArray(event.attendees) ? event.attendees.length : (event.attendeesCount || 0)}
                     image={event.bannerImage || event.image}
                     description={event.description}
                     startDate={event.startDate}

--- a/client/src/pages/StaffUpcomingEvents.tsx
+++ b/client/src/pages/StaffUpcomingEvents.tsx
@@ -95,7 +95,7 @@ export default function StaffUpcomingEvents() {
                     })
                   : "TBA"}
                 location={event.location || "Unknown location"}
-                attendees={event.attendeesCount || 0}
+                attendees={Array.isArray(event.attendees) ? event.attendees.length : (event.attendeesCount || 0)}
                 image={event.bannerImage || event.image}
                 description={event.description}
                 startDate={event.startDate}


### PR DESCRIPTION
This pull request updates how the number of attendees is calculated and displayed across several dashboard and event-related pages. Instead of relying solely on a precomputed `attendeesCount`, the code now checks if the `attendees` property is an array and uses its length if available, providing a more accurate attendee count.

Attendee count calculation improvements:

* Updated attendee count logic in multiple pages (`AdminDashboardPage.tsx`, `Dashboard.tsx`, `EventsOfficeDashboard.tsx`, `Home.tsx`, `ProfessorDashboard.tsx`, `StaffUpcomingEvents.tsx`) to use the length of the `attendees` array when available, falling back to `attendeesCount` otherwise. [[1]](diffhunk://#diff-d7be8f29a6b24403f3a32d8998d4dc5eb79d7ad3db0170b22a21eb70f68f6ee7L239-R239) [[2]](diffhunk://#diff-5ac42d3684825754e97d01eba06bf54d3b18def8e9e575a0d1c066e0cf03963bL154-R154) [[3]](diffhunk://#diff-3b80f2919b2d59e50b1c65c33bea9c96bbc509a42efeb7792c9946a13e0f055aL404-R404) [[4]](diffhunk://#diff-89afd9d1dc263b0fb25b7de782e8da5905de63d47c483bc69807c1449c19be01L85-R85) [[5]](diffhunk://#diff-89afd9d1dc263b0fb25b7de782e8da5905de63d47c483bc69807c1449c19be01L150-R150) [[6]](diffhunk://#diff-bef2acc88ecf997c96127bec07645ddb0f8085febb2616571ca563911739a5b9L259-R259) [[7]](diffhunk://#diff-2e921d128ff0038785fcd1bc22f19fbdf97b564b8f5b94e54a719792dd4dd66bL98-R98)