### PR TITLE
fix(admin): add totalUpcomingCount state to keep it static and update on refresh

### DIFF
--- a/client/src/pages/AdminDashboardPage.tsx
+++ b/client/src/pages/AdminDashboardPage.tsx
@@ -31,6 +31,7 @@ export default function AdminDashboardPage() {
   const [eventsLoading, setEventsLoading] = useState(true);
   const [eventsError, setEventsError] = useState<string | null>(null);
   const [upcomingEvents, setUpcomingEvents] = useState<any[]>([]);
+  const [totalUpcomingCount, setTotalUpcomingCount] = useState<number | null>(null);
   const [approvedEventsCount, setApprovedEventsCount] = useState<number>(0);
   const [approvedLoading, setApprovedLoading] = useState<boolean>(true);
   const [eventTypeFilter, setEventTypeFilter] = useState<
@@ -85,7 +86,9 @@ export default function AdminDashboardPage() {
         }
         const body = await res.json();
         if (!res.ok) throw new Error(body.message || "Failed to fetch upcoming events");
-        setUpcomingEvents(Array.isArray(body.data) ? body.data : body);
+        const eventsList = Array.isArray(body.data) ? body.data : body;
+        setUpcomingEvents(eventsList);
+        setTotalUpcomingCount(eventsList.length);
       } catch (err: any) {
         setEventsError(err.message || "Failed to load upcoming events");
         setUpcomingEvents([]);
@@ -156,7 +159,7 @@ export default function AdminDashboardPage() {
           />
           <StatCard 
             title="Upcoming Events" 
-            value={eventsLoading ? "-" : upcomingEvents.length.toString()} 
+            value={totalUpcomingCount === null ? "-" : totalUpcomingCount.toString()} 
             icon={Calendar} 
           />
           <StatCard 


### PR DESCRIPTION
This pull request improves the way the "Upcoming Events" statistic is calculated and displayed on the `AdminDashboardPage`. The main change is the introduction of a dedicated state variable to track the total count of upcoming events, which helps decouple the display logic from the actual event data array.

**Improvements to event count tracking and display:**

* Added a new state variable `totalUpcomingCount` to store the total number of upcoming events, making the count calculation more explicit and reliable.
* Updated the event fetching logic to set `totalUpcomingCount` based on the length of the fetched events list, ensuring the count is always accurate after data is loaded.
* Modified the "Upcoming Events" stat card to use `totalUpcomingCount` for its value, improving clarity and consistency in the UI.