### PR TITLE
feat(gymSchedule): add cancel functionality for gym sessions with confirmation dialog (req 85)

### DIFF
--- a/client/src/components/GymScheduleViewer.tsx
+++ b/client/src/components/GymScheduleViewer.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { ChevronLeft, ChevronRight, Plus, Pencil } from "lucide-react";
+import { ChevronLeft, ChevronRight, Plus, Pencil, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -11,6 +11,16 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { useToast } from "@/hooks/use-toast";
 import EditGymSessionDialog from "@/components/EditGymSessionDialog";
 
@@ -46,7 +56,9 @@ export default function GymScheduleViewer({ userRole, onCreateClick, navigateToD
   const [loading, setLoading] = useState(true);
   const [currentDate, setCurrentDate] = useState(new Date());
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
+  const [isCancelDialogOpen, setIsCancelDialogOpen] = useState(false);
   const [selectedSession, setSelectedSession] = useState<GymSession | null>(null);
+  const [isCancelling, setIsCancelling] = useState(false);
   const { toast } = useToast();
 
   const month = currentDate.getMonth() + 1; // JavaScript months are 0-indexed
@@ -127,6 +139,59 @@ export default function GymScheduleViewer({ userRole, onCreateClick, navigateToD
     fetchGymSessions(); // Refresh the sessions list
   };
 
+  const handleCancelClick = (session: GymSession) => {
+    setSelectedSession(session);
+    setIsCancelDialogOpen(true);
+  };
+
+  const handleCancelConfirm = async () => {
+    if (!selectedSession) return;
+
+    setIsCancelling(true);
+
+    try {
+      const token = localStorage.getItem("token");
+      if (!token) {
+        throw new Error("Authentication required");
+      }
+
+      const response = await fetch(
+        `http://localhost:4000/api/facilities/gym/sessions/${selectedSession._id}/cancel`,
+        {
+          method: "PATCH",
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        }
+      );
+
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.message || "Failed to cancel session");
+      }
+
+      const data = await response.json();
+
+      toast({
+        title: "Success",
+        description: `Gym session cancelled successfully. ${data.data.notificationsSent || 0} participant(s) notified.`,
+      });
+
+      setIsCancelDialogOpen(false);
+      setSelectedSession(null);
+      fetchGymSessions(); // Refresh the sessions list
+    } catch (error) {
+      console.error("Cancel session error:", error);
+      toast({
+        title: "Error",
+        description: error instanceof Error ? error.message : "Failed to cancel session",
+        variant: "destructive",
+      });
+    } finally {
+      setIsCancelling(false);
+    }
+  };
+
   const formatDate = (dateString: string) => {
     const date = new Date(dateString);
     const day = date.getDate().toString().padStart(2, '0');
@@ -142,6 +207,7 @@ export default function GymScheduleViewer({ userRole, onCreateClick, navigateToD
 
   const canCreateSession = userRole === "events_office";
   const canEditSession = userRole === "events_office";
+  const canCancelSession = userRole === "events_office";
   const canRegister = userRole === "student" || userRole === "staff" || userRole === "ta" || userRole === "professor";
 
   return (
@@ -193,7 +259,7 @@ export default function GymScheduleViewer({ userRole, onCreateClick, navigateToD
                   <TableHead>Instructor</TableHead>
                   <TableHead>Capacity</TableHead>
                   {canRegister && <TableHead>Registration</TableHead>}
-                  {canEditSession && <TableHead>Actions</TableHead>}
+                  {(canEditSession || canCancelSession) && <TableHead>Actions</TableHead>}
                 </TableRow>
               </TableHeader>
               <TableBody>
@@ -246,15 +312,28 @@ export default function GymScheduleViewer({ userRole, onCreateClick, navigateToD
                           </Button>
                         </TableCell>
                       )}
-                      {canEditSession && (
+                      {(canEditSession || canCancelSession) && (
                         <TableCell>
-                          <button
-                            onClick={() => handleEditClick(session)}
-                            className="p-2 hover:bg-accent rounded-md transition-colors cursor-pointer"
-                            aria-label="Edit session"
-                          >
-                            <Pencil className="h-4 w-4 text-muted-foreground hover:text-foreground" />
-                          </button>
+                          <div className="flex items-center gap-1">
+                            {canEditSession && (
+                              <button
+                                onClick={() => handleEditClick(session)}
+                                className="p-2 hover:bg-accent rounded-md transition-colors cursor-pointer"
+                                aria-label="Edit session"
+                              >
+                                <Pencil className="h-4 w-4 text-muted-foreground hover:text-foreground" />
+                              </button>
+                            )}
+                            {canCancelSession && (
+                              <button
+                                onClick={() => handleCancelClick(session)}
+                                className="p-2 hover:bg-accent rounded-md transition-colors cursor-pointer"
+                                aria-label="Cancel session"
+                              >
+                                <X className="h-4 w-4 text-muted-foreground hover:text-destructive" />
+                              </button>
+                            )}
+                          </div>
                         </TableCell>
                       )}
                     </TableRow>
@@ -273,6 +352,47 @@ export default function GymScheduleViewer({ userRole, onCreateClick, navigateToD
         session={selectedSession}
         onSuccess={handleEditSuccess}
       />
+
+      {/* Cancel Confirmation Dialog */}
+      <AlertDialog open={isCancelDialogOpen} onOpenChange={setIsCancelDialogOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Cancel Gym Session</AlertDialogTitle>
+            <AlertDialogDescription>
+              Are you sure you want to cancel this gym session?
+              {selectedSession && selectedSession.attendees && selectedSession.attendees.length > 0 && (
+                <span> {selectedSession.attendees.length} registered participant{selectedSession.attendees.length !== 1 ? 's' : ''} will be notified via email.</span>
+              )}
+              {selectedSession && (
+                <div className="mt-4 p-3 bg-muted rounded-md">
+                  <p className="font-medium text-foreground">
+                    {GYM_SESSION_TYPES[selectedSession.type] || selectedSession.type}
+                  </p>
+                  <p className="text-sm mt-1">
+                    {formatDate(selectedSession.date)} at {selectedSession.startTime}
+                  </p>
+                  <p className="text-sm">
+                    Instructor: {selectedSession.instructor}
+                  </p>
+                </div>
+              )}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isCancelling}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={(e) => {
+                e.preventDefault();
+                handleCancelConfirm();
+              }}
+              disabled={isCancelling}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90 outline-none border-0 shadow-none focus:outline-none focus:border-0 focus:shadow-none focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0"
+            >
+              {isCancelling ? "Cancelling..." : "Confirm Cancellation"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }


### PR DESCRIPTION
## Overview

This PR adds a cancel button to the gym schedule viewer, allowing Events Office users to cancel gym sessions directly from the `Sports Facilities` page. The implementation includes a confirmation dialog and integrates with the existing cancellation API endpoint.

## Changes

### Component Updates

**`GymScheduleViewer.tsx`**

#### New Features
- Added cancel button (X icon) next to the edit button in the Actions column
- Implemented confirmation dialog before cancellation
- Integrated with `PATCH /api/facilities/gym/sessions/:sessionId/cancel` API endpoint
- Added participant count display in confirmation dialog (only shown if > 0)
- Success toast shows number of participants notified

#### UI/UX Design
- **Cancel Button**: Minimal X icon matching the existing pen icon design
  - Appears only for Events Office users
  - Red hover effect (`hover:text-destructive`)
  - Consistent spacing and styling with edit button
  
- **Confirmation Dialog**: 
  - Shows session details (type, date, time, instructor)
  - Displays participant count when applicable (e.g., "3 registered participants will be notified via email")
  - Two actions: Cancel (gray) or Confirm Cancellation (red)
  - Loading state during API call ("Cancelling...")
  - All focus outlines removed from Confirm button for clean appearance

#### State Management
```typescript
const [isCancelDialogOpen, setIsCancelDialogOpen] = useState(false);
const [isCancelling, setIsCancelling] = useState(false);
```

#### API Integration
```typescript
const handleCancelConfirm = async () => {
  // PATCH request to /api/facilities/gym/sessions/:sessionId/cancel
  // Shows success toast with notification count
  // Refreshes session list on success
  // Handles errors gracefully
};
```

## Visual Design

### Actions Column Layout
```
[Pen Icon] [X Icon]
   Edit      Cancel
```

Both icons have:
- Same size (h-4 w-4)
- Same padding (p-2)
- Same hover background (hover:bg-accent)
- Consistent rounded corners
- Smooth transitions

### Confirmation Dialog
```
┌─────────────────────────────────┐
│ Cancel Gym Session              │
├─────────────────────────────────┤
│ Are you sure you want to cancel │
│ this gym session? N participants│
│ will be notified via email.     │
│                                  │
│ ┌───────────────────────────┐  │
│ │ Cross Circuit             │  │
│ │ 19/11/2025 at 12:00 PM    │  │
│ │ Instructor: John Doe      │  │
│ └───────────────────────────┘  │
│                                  │
│     [Cancel]  [Confirm Cancel]  │
└─────────────────────────────────┘
```

## API Contract

### Endpoint
```
PATCH /api/facilities/gym/sessions/:sessionId/cancel
```

### Headers
```
Authorization: Bearer <token>
```

### Response Example
```json
{
  "success": true,
  "message": "Gym session cancelled successfully.",
  "data": {
    "session": { /* updated session with status: "cancelled" */ },
    "notificationsSent": 3
  }
}
```

## User Flow

1. Events Office user clicks X icon on a session
2. Confirmation dialog appears with session details
3. Dialog shows participant count (if > 0)
4. User clicks "Confirm Cancellation"
5. Button shows loading state ("Cancelling...")
6. API request sent to cancel endpoint
7. On success:
   - Success toast displays with notification count
   - Dialog closes
   - Session list refreshes (cancelled session removed from view)
8. On error:
   - Error toast displays with message
   - Dialog remains open

## Authorization

- Cancel button only visible when `userRole === "events_office"`
- Backend validates Events Office role
- Frontend handles 403 errors gracefully

## Error Handling

- Network errors: Displays descriptive toast
- API errors: Shows backend error message
- Authentication errors: Prompts for login
- Validation errors: Shows specific validation message

## Testing Checklist

- [ ] Cancel button appears for Events Office users only
- [ ] Cancel button does not appear for other roles
- [ ] Clicking X icon opens confirmation dialog
- [ ] Dialog shows correct session details
- [ ] Participant count displays only when > 0
- [ ] Singular/plural participant text works correctly
- [ ] Confirm button has no blue focus outline
- [ ] Loading state shows during cancellation
- [ ] Success toast shows notification count
- [ ] Session list refreshes after cancellation
- [ ] Cancelled sessions no longer appear
- [ ] Error toast shows on API failure
- [ ] Dialog closes on successful cancellation
- [ ] Both icons align properly in Actions column

## Future Enhancements

- Add undo functionality for accidental cancellations
- Show cancellation reason input field
- Add bulk cancellation for multiple sessions
- Add animation when session is removed from list
- Show cancelled sessions with strikethrough option

## Screenshots/Demo

<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/243a6f57-cb5b-408c-8833-21627d37ae12" />
<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/5a6561a0-d47e-4a00-b57e-b3c2199e8d08" />
<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/10a1bc75-6977-4f7d-8ef4-e42206c7e3d1" />
<img width="1554" height="843" alt="image" src="https://github.com/user-attachments/assets/052cd1d1-9b7e-49ff-8874-2e708e051187" />
<img width="1550" height="826" alt="image" src="https://github.com/user-attachments/assets/9b9e0018-01a4-45e2-9029-73fd0444a246" />
<img width="1545" height="838" alt="image" src="https://github.com/user-attachments/assets/1b42c34c-8abb-4f9d-98db-f7e72335cc63" />


---
