### PR TITLE
feat(events): add archive functionality for events by Events Office

### DIFF
--- a/server/src/features/events/event.controller.js
+++ b/server/src/features/events/event.controller.js
@@ -593,4 +593,28 @@ export class EventsController {
       next(err);
     }
   }
+
+  // Archive an event (only after event endDate has passed)
+  async archiveEvent(req, res, next) {
+    try {
+      if (!req.user) {
+        throw new ApiError(401, "Unauthorized");
+      }
+
+      if (req.user.role !== "events_office") {
+        throw new ApiError(
+          403,
+          "Forbidden: Only Events Office can archive events"
+        );
+      }
+
+      const event = await eventService.archiveEvent(req.params.id, req.user);
+
+      return res
+        .status(200)
+        .json(new ApiResponse(200, event, "Event archived successfully"));
+    } catch (err) {
+      next(err);
+    }
+  }
 }

--- a/server/src/features/events/event.model.js
+++ b/server/src/features/events/event.model.js
@@ -20,7 +20,7 @@ const eventSchema = new Schema(
     status: {
       type: String,
       required: true,
-      enum: ["pending", "approved", "rejected", "needs_revision"],
+      enum: ["pending", "approved", "rejected", "needs_revision", "archived"],
       default: function () {
         // If eventType is 'workshop', default to 'pending', else 'approved'
         return this.eventType === "workshop" ? "pending" : "approved";
@@ -57,6 +57,8 @@ const eventSchema = new Schema(
     },
 
     deletedAt: { type: Date, default: null }, // soft delete,
+    // Timestamp when an event was archived by Events Office (null if not archived)
+    archivedAt: { type: Date, default: null },
 
     price: {
       type: Number,

--- a/server/src/features/events/event.model.js
+++ b/server/src/features/events/event.model.js
@@ -59,6 +59,14 @@ const eventSchema = new Schema(
     deletedAt: { type: Date, default: null }, // soft delete,
     // Timestamp when an event was archived by Events Office (null if not archived)
     archivedAt: { type: Date, default: null },
+    // Track which Events Office user archived the event
+    archivedBy: { 
+      type: Schema.Types.ObjectId, 
+      ref: 'User',
+      required: function() { 
+        return this.archivedAt !== null; 
+      }
+    },
 
     price: {
       type: Number,
@@ -119,9 +127,12 @@ eventSchema.index({ startDate: 1 }); // Index for date filtering
 eventSchema.index({ deletedAt: 1 }); // Index for soft delete filtering
 eventSchema.index({ createdBy: 1 }); // Index for createdBy lookup
 eventSchema.index({ professors: 1 }); // Index for professors array lookup
+eventSchema.index({ archivedAt: 1 }); // Index for archive filtering
+eventSchema.index({ archivedBy: 1 }); // Index for archive auditing
 
 // Compound indexes for common query patterns
-eventSchema.index({ status: 1, startDate: 1, deletedAt: 1 }); // For upcoming events query
+eventSchema.index({ status: 1, startDate: 1, deletedAt: 1, archivedAt: 1 }); // For upcoming/active events query
+eventSchema.index({ archivedAt: 1, archivedBy: 1 }); // For archive auditing queries
 eventSchema.index({ name: "text", description: "text" }); // Text index for name and description search
 
 export const Event = mongoose.model("Event", eventSchema);

--- a/server/src/features/events/event.route.js
+++ b/server/src/features/events/event.route.js
@@ -83,6 +83,14 @@ router.patch(
   eventsController.rejectWorkshop.bind(eventsController)
 );
 
+// Archive event (only Events Office, and only after endDate has passed)
+router.patch(
+  "/:id/archive",
+  authMiddleware,
+  roleMiddleware(["events_office"]),
+  eventsController.archiveEvent.bind(eventsController)
+);
+
 // Edit a workshop that needs revision
 router.patch(
   "/workshops/:workshopId",

--- a/server/src/features/events/event.service.js
+++ b/server/src/features/events/event.service.js
@@ -584,32 +584,51 @@ export async function getAllEvents() {
     throw new ApiError(500, "Error fetching events");
   }
 }
-
 export const archiveEvent = async (eventId, user) => {
   // Authorization
   if (!user || user.role !== "events_office") {
     throw new ApiError(403, "Forbidden: Only Events Office can archive events");
   }
 
-  const event = await Event.findById(eventId);
-  if (!event) throw new ApiError(404, "Event not found");
-
-  // Ensure event has an endDate
-  if (!event.endDate) {
-    throw new ApiError(400, "Event does not have an endDate and cannot be archived");
-  }
-
   const now = new Date();
-  const endDate = new Date(event.endDate);
 
-  // Only allow archiving after the event has fully ended
-  if (endDate > now) {
-    throw new ApiError(400, "Cannot archive an event before its end date");
+  // Atomic update — this ensures only eligible events are modified
+  const updatedEvent = await Event.findOneAndUpdate(
+    {
+      _id: eventId,
+      deletedAt: null,                // not deleted
+      status: { $ne: "archived" },    // not already archived
+      endDate: { $lte: now },         // event has ended
+    },
+    {
+      $set: {
+        status: "archived",
+        archivedAt: now,
+        archivedBy: user.id,
+      },
+    },
+    { new: true } // return the updated document
+  );
+
+  // Handle if no document was updated (meaning one of the conditions failed)
+  if (!updatedEvent) {
+    // Now check what the reason could be
+    const existingEvent = await Event.findById(eventId);
+
+    if (!existingEvent) {
+      throw new ApiError(404, "Event not found");
+    } else if (existingEvent.deletedAt !== null) {
+      throw new ApiError(400, "Cannot archive a deleted event");
+    } else if (existingEvent.status === "archived") {
+      throw new ApiError(400, "Event is already archived");
+    } else if (!existingEvent.endDate) {
+      throw new ApiError(400, "Event does not have an endDate and cannot be archived");
+    } else if (new Date(existingEvent.endDate) > now) {
+      throw new ApiError(400, "Cannot archive an event before its end date");
+    } else {
+      throw new ApiError(400, "Event could not be archived due to unknown reason");
+    }
   }
 
-  event.status = "archived";
-  event.archivedAt = now;
-
-  await event.save();
-  return event;
+  return updatedEvent;
 };

--- a/server/src/features/events/event.service.js
+++ b/server/src/features/events/event.service.js
@@ -584,3 +584,32 @@ export async function getAllEvents() {
     throw new ApiError(500, "Error fetching events");
   }
 }
+
+export const archiveEvent = async (eventId, user) => {
+  // Authorization
+  if (!user || user.role !== "events_office") {
+    throw new ApiError(403, "Forbidden: Only Events Office can archive events");
+  }
+
+  const event = await Event.findById(eventId);
+  if (!event) throw new ApiError(404, "Event not found");
+
+  // Ensure event has an endDate
+  if (!event.endDate) {
+    throw new ApiError(400, "Event does not have an endDate and cannot be archived");
+  }
+
+  const now = new Date();
+  const endDate = new Date(event.endDate);
+
+  // Only allow archiving after the event has fully ended
+  if (endDate > now) {
+    throw new ApiError(400, "Cannot archive an event before its end date");
+  }
+
+  event.status = "archived";
+  event.archivedAt = now;
+
+  await event.save();
+  return event;
+};


### PR DESCRIPTION
REQ-47 (Backend):
As an events office, I want to archive events that have already passed. (This applies to all kinds of event)


### **_📄 Description_**
This PR introduces the archiveEvent functionality, enabling authorized events_office users to archive events that have already ended.
The function ensures proper authorization, logical validation, and safe database updates using an atomic MongoDB query.


### ⚙️ **_Implementation Details_**
- **Authorization**
Only users with the role events_office can archive events. Unauthorized users receive a 403 Forbidden response.
- **Atomic Update Logic**
- **Validation & Error Handling**
Returns 404 if the event does not exist.
Returns 400 if:
The event is already archived.
The event has been deleted.
The event has no end date.
The event’s end date is still in the future.
Returns 403 if the user is not events_office.
- **Audit Tracking**
Stores archivedAt timestamp.
Records the ID of the user who performed the archiving (archivedBy).

### **_Testing Instructions_**
Log in as a user with role events_office to obtain a JWT token.
Send a PATCH request to:
PATCH /api/events/:id/archive
Authorization: Bearer <token>


### **_Expected responses:_**
✅ 200 OK – Event archived successfully.
❌ 400 Bad Request – Event not ended, deleted, or already archived.
❌ 403 Forbidden – User not events_office.
❌ 404 Not Found – Invalid or non-existent event ID.