### PR TITLE
feat(events): make startTime and endTime required for non-platform_booth events

### DIFF
--- a/server/src/features/events/event.model.js
+++ b/server/src/features/events/event.model.js
@@ -12,9 +12,13 @@ const eventSchema = new Schema(
     description: { type: String, required: true },
     location: { type: String, required: true },
     startDate: { type: Date, required: true },
-    startTime: { type: String },
+    startTime: { type: String, required: function () {
+      return this.eventType !== "platform_booth";
+    }},
     endDate: { type: Date, required: true },
-    endTime: { type: String },
+    endTime: { type: String, required: function () {
+      return this.eventType !== "platform_booth";
+    }},
     registrationDeadline: { type: Date, required: true },
 
     status: {


### PR DESCRIPTION
This pull request updates the event schema validation logic to make the `startTime` and `endTime` fields conditionally required based on the event type. Now, these fields are only required when the event type is not `"platform_booth"`.

Schema validation improvements:

* Updated the `eventSchema` in `event.model.js` so that `startTime` and `endTime` are required only if the `eventType` is not `"platform_booth"`.