### PR TITLE
feat(vendor): add Loyalty Program application button and dialog

### DIFF
--- a/client/src/components/LoyaltyProgramDialog.tsx
+++ b/client/src/components/LoyaltyProgramDialog.tsx
@@ -1,0 +1,171 @@
+import { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
+import { useToast } from "@/hooks/use-toast";
+
+interface LoyaltyProgramDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export default function LoyaltyProgramDialog({
+  open,
+  onOpenChange,
+}: LoyaltyProgramDialogProps) {
+  const { toast } = useToast();
+  const [discountRate, setDiscountRate] = useState<number>(20);
+  const [promoCode, setPromoCode] = useState<string>("SAVE20");
+  const [terms, setTerms] = useState<string>(
+    "Valid for all purchases over 100 EGP."
+  );
+  const [expiryDate, setExpiryDate] = useState<string>("2026-01-01");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = async () => {
+    if (!discountRate || !promoCode || !terms) {
+      toast({
+        title: "Validation Error",
+        description: "All fields are required.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      // Get the token from localStorage or your auth context
+      const token = localStorage.getItem("token"); // or get from your auth context
+
+      if (!token) {
+        throw new Error("Authentication required. Please log in again.");
+      }
+
+      const response = await fetch(
+        "http://localhost:4000/api/loyalty-partners/apply",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({
+            discountRate,
+            promoCode,
+            termsAndConditions: terms,
+            expiryDate,
+          }),
+        }
+      );
+
+      const data = await response.json().catch(() => ({})); // Handle non-JSON responses
+
+      if (!response.ok) {
+        // If the server returned an error message, use it, otherwise use a default message
+        const errorMessage =
+          data.message || `HTTP error! status: ${response.status}`;
+        throw new Error(errorMessage);
+      }
+
+      toast({
+        title: "Success",
+        description:
+          data.message ||
+          "You applied to the GUC Loyalty Program successfully!",
+      });
+      onOpenChange(false);
+    } catch (error: any) {
+      console.error("Error applying to loyalty program:", error);
+
+      // More specific error messages based on the error type
+      let errorMessage = "Failed to apply to the loyalty program";
+
+      if (error.message.includes("Failed to fetch")) {
+        errorMessage =
+          "Unable to connect to the server. Please check your internet connection.";
+      } else if (error.message) {
+        errorMessage = error.message;
+      }
+
+      toast({
+        title: "Error",
+        description: errorMessage,
+        variant: "destructive",
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Apply to GUC Loyalty Program</DialogTitle>
+          <DialogDescription>
+            Fill the form below to participate in the program.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="discountRate">Discount Rate (%)</Label>
+            <Input
+              id="discountRate"
+              type="number"
+              value={discountRate}
+              onChange={(e) => setDiscountRate(Number(e.target.value))}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="promoCode">Promo Code</Label>
+            <Input
+              id="promoCode"
+              value={promoCode}
+              onChange={(e) => setPromoCode(e.target.value)}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="terms">Terms and Conditions</Label>
+            <Textarea
+              id="terms"
+              value={terms}
+              onChange={(e) => setTerms(e.target.value)}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="expiryDate">Expiry Date</Label>
+            <Input
+              id="expiryDate"
+              type="date"
+              value={expiryDate}
+              onChange={(e) => setExpiryDate(e.target.value)}
+            />
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={isSubmitting}
+          >
+            Cancel
+          </Button>
+          <Button onClick={handleSubmit} disabled={isSubmitting}>
+            {isSubmitting ? "Submitting..." : "Apply"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client/src/components/LoyaltyProgramDialog.tsx
+++ b/client/src/components/LoyaltyProgramDialog.tsx
@@ -23,16 +23,14 @@ export default function LoyaltyProgramDialog({
   onOpenChange,
 }: LoyaltyProgramDialogProps) {
   const { toast } = useToast();
-  const [discountRate, setDiscountRate] = useState<number>(20);
-  const [promoCode, setPromoCode] = useState<string>("SAVE20");
-  const [terms, setTerms] = useState<string>(
-    "Valid for all purchases over 100 EGP."
-  );
-  const [expiryDate, setExpiryDate] = useState<string>("2026-01-01");
+  const [discountRate, setDiscountRate] = useState<number | "">("");
+  const [promoCode, setPromoCode] = useState<string>("");
+  const [terms, setTerms] = useState<string>("");
+  const [expiryDate, setExpiryDate] = useState<string>("");
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const handleSubmit = async () => {
-    if (!discountRate || !promoCode || !terms) {
+    if (discountRate === "" || !promoCode || !terms || !expiryDate) {
       toast({
         title: "Validation Error",
         description: "All fields are required.",
@@ -59,7 +57,7 @@ export default function LoyaltyProgramDialog({
             Authorization: `Bearer ${token}`,
           },
           body: JSON.stringify({
-            discountRate,
+            discountRate: Number(discountRate),
             promoCode,
             termsAndConditions: terms,
             expiryDate,
@@ -123,7 +121,12 @@ export default function LoyaltyProgramDialog({
               id="discountRate"
               type="number"
               value={discountRate}
-              onChange={(e) => setDiscountRate(Number(e.target.value))}
+              placeholder="e.g., 20"
+              onChange={(e) =>
+                setDiscountRate(
+                  e.target.value === "" ? "" : Number(e.target.value)
+                )
+              }
             />
           </div>
           <div className="space-y-2">
@@ -131,6 +134,7 @@ export default function LoyaltyProgramDialog({
             <Input
               id="promoCode"
               value={promoCode}
+              placeholder="e.g., SAVE20"
               onChange={(e) => setPromoCode(e.target.value)}
             />
           </div>
@@ -139,6 +143,7 @@ export default function LoyaltyProgramDialog({
             <Textarea
               id="terms"
               value={terms}
+              placeholder="e.g., Valid for all purchases over 100 EGP"
               onChange={(e) => setTerms(e.target.value)}
             />
           </div>
@@ -148,6 +153,7 @@ export default function LoyaltyProgramDialog({
               id="expiryDate"
               type="date"
               value={expiryDate}
+              min={new Date().toISOString().split("T")[0]}
               onChange={(e) => setExpiryDate(e.target.value)}
             />
           </div>

--- a/client/src/components/VendorHeader.tsx
+++ b/client/src/components/VendorHeader.tsx
@@ -14,6 +14,9 @@ import ThemeToggle from "./ThemeToggle";
 import Logo from "./Logo";
 import ProfileMenu from "./ProfileMenu";
 import { useLocation } from "wouter";
+import { useState, useEffect } from "react";
+import { Gift } from "lucide-react";
+import LoyaltyProgramDialog from "./LoyaltyProgramDialog";
 
 interface VendorHeaderProps {
   onSearch?: (query: string) => void;
@@ -30,12 +33,26 @@ export default function VendorHeader({
 }: VendorHeaderProps) {
   const [, setLocation] = useLocation();
 
+  const [isLoyaltyDialogOpen, setIsLoyaltyDialogOpen] = useState(false);
+
+  // Check URL hash on component mount and when it changes
+  useEffect(() => {
+    const hash = window.location.hash.substring(1);
+    if (hash === "loyalty-program") {
+      setIsLoyaltyDialogOpen(true);
+    }
+  }, []);
+
   const handleTabClick = (tab: string) => {
     if (onTabChange) {
       onTabChange(tab);
     }
-    // Update URL hash
     window.location.hash = tab;
+  };
+
+  const handleLoyaltyProgramClick = () => {
+    window.location.hash = "loyalty-program";
+    setIsLoyaltyDialogOpen(true);
   };
 
   return (
@@ -124,8 +141,35 @@ export default function VendorHeader({
             <XCircle className="h-4 w-4" />
             Rejected Requests
           </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            className={`gap-2 ${window.location.hash === "#loyalty-program" ? "underline decoration-primary decoration-2" : ""}`}
+            onClick={handleLoyaltyProgramClick}
+            data-testid="button-nav-loyalty"
+          >
+            <Gift className="h-4 w-4" />
+            Loyalty Program
+          </Button>
         </div>
       </div>
+
+      <LoyaltyProgramDialog
+        open={isLoyaltyDialogOpen}
+        onOpenChange={(open) => {
+          setIsLoyaltyDialogOpen(open);
+          if (!open) {
+            // Remove the hash when closing the dialog
+            window.history.pushState(
+              "",
+              document.title,
+              window.location.pathname + window.location.search
+            );
+          } else {
+            window.location.hash = "loyalty-program";
+          }
+        }}
+      />
     </header>
   );
 }


### PR DESCRIPTION
This PR implements the GUC Loyalty Program application feature for vendors.

Changes:

Added a Loyalty Program button next to the “Rejected Requests” tab in the VendorHeader.

Clicking the button updates the URL hash to #loyalty-program and opens the LoyaltyProgramDialog, consistent with other header tabs.

Created the LoyaltyProgramDialog component with form fields for Discount Rate, Promo Code, Terms and Conditions, and Expiry Date.

Form validation ensures all fields are filled.

Submits data to the backend API at http://localhost:4000/api/loyalty-partners/apply.

Added authorization header to API requests using the JWT token stored in localStorage.

Improved error handling with descriptive messages from the server and handling of missing/invalid tokens.

Dialog integration with URL hash ensures refreshing the page maintains the open state.

Testing:

Button appears next to the “Rejected Requests” tab.

Dialog opens when clicking the button or navigating to #loyalty-program.

Successful form submission shows success toast.

API errors show descriptive toasts.