### PR TITLE
Feature/loyalty cancel participation

### DIFF
--- a/client/src/components/LoyaltyProgramDialog.tsx
+++ b/client/src/components/LoyaltyProgramDialog.tsx
@@ -1,10 +1,10 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
-  DialogDescription,
   DialogFooter,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
@@ -12,10 +12,22 @@ import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
 import { useToast } from "@/hooks/use-toast";
+import { Gift, X } from "lucide-react";
 
 interface LoyaltyProgramDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+}
+
+interface VendorStatus {
+  hasParticipation: boolean;
+  status: "active" | "cancelled" | null;
+  details?: {
+    discountRate: number;
+    promoCode: string;
+    termsAndConditions: string;
+    expiryDate: string;
+  };
 }
 
 export default function LoyaltyProgramDialog({
@@ -28,6 +40,103 @@ export default function LoyaltyProgramDialog({
   const [terms, setTerms] = useState<string>("");
   const [expiryDate, setExpiryDate] = useState<string>("");
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [vendorStatus, setVendorStatus] = useState<VendorStatus | null>(null);
+  const [isLoadingStatus, setIsLoadingStatus] = useState(false);
+
+  // Fetch vendor status when dialog opens
+  useEffect(() => {
+    if (open) {
+      fetchVendorStatus();
+    }
+  }, [open]);
+
+  const fetchVendorStatus = async () => {
+    setIsLoadingStatus(true);
+    try {
+      const token = localStorage.getItem("token");
+      if (!token) {
+        throw new Error("Authentication required. Please log in again.");
+      }
+
+      const response = await fetch(
+        "http://localhost:4000/api/loyalty-partners/status",
+        {
+          method: "GET",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+        }
+      );
+
+      const data = await response.json().catch(() => ({}));
+
+      if (!response.ok) {
+        throw new Error(
+          data.message || `HTTP error! status: ${response.status}`
+        );
+      }
+
+      setVendorStatus(data.data);
+    } catch (error: any) {
+      console.error("Error fetching vendor status:", error);
+      toast({
+        title: "Error",
+        description: "Failed to fetch loyalty program status",
+        variant: "destructive",
+      });
+    } finally {
+      setIsLoadingStatus(false);
+    }
+  };
+
+  const handleCancel = async () => {
+    setIsSubmitting(true);
+    try {
+      const token = localStorage.getItem("token");
+      if (!token) {
+        throw new Error("Authentication required. Please log in again.");
+      }
+
+      const response = await fetch(
+        "http://localhost:4000/api/loyalty-partners/cancel",
+        {
+          method: "DELETE",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+        }
+      );
+
+      const data = await response.json().catch(() => ({}));
+
+      if (!response.ok) {
+        throw new Error(
+          data.message || `HTTP error! status: ${response.status}`
+        );
+      }
+
+      toast({
+        title: "Success",
+        description:
+          data.message ||
+          "Successfully cancelled loyalty program participation",
+      });
+
+      // Refresh status after cancellation
+      await fetchVendorStatus();
+    } catch (error: any) {
+      console.error("Error cancelling loyalty program:", error);
+      toast({
+        title: "Error",
+        description: error.message || "Failed to cancel loyalty program",
+        variant: "destructive",
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
 
   const handleSubmit = async () => {
     if (discountRate === "" || !promoCode || !terms || !expiryDate) {
@@ -106,70 +215,203 @@ export default function LoyaltyProgramDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-lg">
+      <DialogContent
+        className={
+          vendorStatus?.status === "cancelled" ? "max-w-sm" : "max-w-lg"
+        }
+      >
         <DialogHeader>
-          <DialogTitle>Apply to GUC Loyalty Program</DialogTitle>
+          <DialogTitle className="flex items-center gap-2">
+            <Gift className="h-5 w-5" />
+            {isLoadingStatus
+              ? "Loading..."
+              : vendorStatus?.status === "active"
+                ? "Loyalty Program Status"
+                : vendorStatus?.status === "cancelled"
+                  ? "Reapply to Loyalty Program"
+                  : "Apply to GUC Loyalty Program"}
+          </DialogTitle>
           <DialogDescription>
-            Fill the form below to participate in the program.
+            {isLoadingStatus
+              ? "Checking your loyalty program status..."
+              : vendorStatus?.status === "active"
+                ? "You currently have an active participation in the GUC Loyalty Program."
+                : vendorStatus?.status === "cancelled"
+                  ? "You previously participated in the GUC Loyalty Program. You can apply again below."
+                  : "Fill the form below to participate in the program."}
           </DialogDescription>
         </DialogHeader>
 
-        <div className="space-y-4">
-          <div className="space-y-2">
-            <Label htmlFor="discountRate">Discount Rate (%)</Label>
-            <Input
-              id="discountRate"
-              type="number"
-              value={discountRate}
-              placeholder="e.g., 20"
-              onChange={(e) =>
-                setDiscountRate(
-                  e.target.value === "" ? "" : Number(e.target.value)
-                )
-              }
-            />
+        {isLoadingStatus ? (
+          <div className="flex items-center justify-center py-8">
+            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
           </div>
-          <div className="space-y-2">
-            <Label htmlFor="promoCode">Promo Code</Label>
-            <Input
-              id="promoCode"
-              value={promoCode}
-              placeholder="e.g., SAVE20"
-              onChange={(e) => setPromoCode(e.target.value)}
-            />
+        ) : vendorStatus?.status === "active" ? (
+          <div className="space-y-4">
+            <div className="bg-green-50 border border-green-200 rounded-lg p-4">
+              <h4 className="font-medium text-green-800 mb-2">
+                Active Participation Details
+              </h4>
+              <div className="space-y-2 text-sm">
+                <div className="flex justify-between">
+                  <span className="text-gray-600">Discount Rate:</span>
+                  <span className="font-medium">
+                    {vendorStatus.details?.discountRate}%
+                  </span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-gray-600">Promo Code:</span>
+                  <span className="font-medium">
+                    {vendorStatus.details?.promoCode}
+                  </span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-gray-600">Expiry Date:</span>
+                  <span className="font-medium">
+                    {vendorStatus.details?.expiryDate
+                      ? new Date(
+                          vendorStatus.details.expiryDate
+                        ).toLocaleDateString()
+                      : "No expiry"}
+                  </span>
+                </div>
+                <div className="mt-3 pt-3 border-t border-green-200">
+                  <p className="text-xs text-gray-600">
+                    {vendorStatus.details?.termsAndConditions}
+                  </p>
+                </div>
+              </div>
+            </div>
           </div>
+        ) : vendorStatus?.status === "cancelled" ? (
           <div className="space-y-2">
-            <Label htmlFor="terms">Terms and Conditions</Label>
-            <Textarea
-              id="terms"
-              value={terms}
-              placeholder="e.g., Valid for all purchases over 100 EGP"
-              onChange={(e) => setTerms(e.target.value)}
-            />
+            <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-2">
+              <h4 className="font-medium text-yellow-800 text-xs mb-1">
+                Previous Participation
+              </h4>
+              <p className="text-xs text-yellow-700">
+                Cancelled. You can apply again.
+              </p>
+            </div>
+            {/* Show application form for reapplication */}
+            <div className="space-y-2">
+              <div className="space-y-1">
+                <Label htmlFor="discountRate">Discount Rate (%)</Label>
+                <Input
+                  id="discountRate"
+                  type="number"
+                  value={discountRate}
+                  placeholder="e.g., 20"
+                  onChange={(e) =>
+                    setDiscountRate(
+                      e.target.value === "" ? "" : Number(e.target.value)
+                    )
+                  }
+                />
+              </div>
+              <div className="space-y-1">
+                <Label htmlFor="promoCode">Promo Code</Label>
+                <Input
+                  id="promoCode"
+                  value={promoCode}
+                  placeholder="e.g., SAVE20"
+                  onChange={(e) => setPromoCode(e.target.value)}
+                />
+              </div>
+              <div className="space-y-1">
+                <Label htmlFor="terms">Terms and Conditions</Label>
+                <Textarea
+                  id="terms"
+                  value={terms}
+                  placeholder="e.g., Valid for all purchases over 100 EGP"
+                  onChange={(e) => setTerms(e.target.value)}
+                />
+              </div>
+              <div className="space-y-1">
+                <Label htmlFor="expiryDate">Expiry Date</Label>
+                <Input
+                  id="expiryDate"
+                  type="date"
+                  value={expiryDate}
+                  min={new Date().toISOString().split("T")[0]}
+                  onChange={(e) => setExpiryDate(e.target.value)}
+                />
+              </div>
+            </div>
           </div>
-          <div className="space-y-2">
-            <Label htmlFor="expiryDate">Expiry Date</Label>
-            <Input
-              id="expiryDate"
-              type="date"
-              value={expiryDate}
-              min={new Date().toISOString().split("T")[0]}
-              onChange={(e) => setExpiryDate(e.target.value)}
-            />
+        ) : (
+          /* Show application form for new applicants */
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="discountRate">Discount Rate (%)</Label>
+              <Input
+                id="discountRate"
+                type="number"
+                value={discountRate}
+                placeholder="e.g., 20"
+                onChange={(e) =>
+                  setDiscountRate(
+                    e.target.value === "" ? "" : Number(e.target.value)
+                  )
+                }
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="promoCode">Promo Code</Label>
+              <Input
+                id="promoCode"
+                value={promoCode}
+                placeholder="e.g., SAVE20"
+                onChange={(e) => setPromoCode(e.target.value)}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="terms">Terms and Conditions</Label>
+              <Textarea
+                id="terms"
+                value={terms}
+                placeholder="e.g., Valid for all purchases over 100 EGP"
+                onChange={(e) => setTerms(e.target.value)}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="expiryDate">Expiry Date</Label>
+              <Input
+                id="expiryDate"
+                type="date"
+                value={expiryDate}
+                min={new Date().toISOString().split("T")[0]}
+                onChange={(e) => setExpiryDate(e.target.value)}
+              />
+            </div>
           </div>
-        </div>
+        )}
 
         <DialogFooter>
           <Button
             variant="outline"
             onClick={() => onOpenChange(false)}
-            disabled={isSubmitting}
+            disabled={isSubmitting || isLoadingStatus}
           >
-            Cancel
+            {vendorStatus?.status === "active" ? "Close" : "Cancel"}
           </Button>
-          <Button onClick={handleSubmit} disabled={isSubmitting}>
-            {isSubmitting ? "Submitting..." : "Apply"}
-          </Button>
+          {vendorStatus?.status === "active" ? (
+            <Button
+              variant="destructive"
+              onClick={handleCancel}
+              disabled={isSubmitting || isLoadingStatus}
+            >
+              {isSubmitting ? "Cancelling..." : "Cancel Participation"}
+            </Button>
+          ) : vendorStatus?.status === "cancelled" ||
+            (!isLoadingStatus && !vendorStatus?.hasParticipation) ? (
+            <Button
+              onClick={handleSubmit}
+              disabled={isSubmitting || isLoadingStatus}
+            >
+              {isSubmitting ? "Submitting..." : "Apply"}
+            </Button>
+          ) : null}
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/client/src/components/LoyaltyProgramDialog.tsx
+++ b/client/src/components/LoyaltyProgramDialog.tsx
@@ -1,0 +1,171 @@
+import { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
+import { useToast } from "@/hooks/use-toast";
+
+interface LoyaltyProgramDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export default function LoyaltyProgramDialog({
+  open,
+  onOpenChange,
+}: LoyaltyProgramDialogProps) {
+  const { toast } = useToast();
+  const [discountRate, setDiscountRate] = useState<number>(20);
+  const [promoCode, setPromoCode] = useState<string>("SAVE20");
+  const [terms, setTerms] = useState<string>(
+    "Valid for all purchases over 100 EGP."
+  );
+  const [expiryDate, setExpiryDate] = useState<string>("2026-01-01");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = async () => {
+    if (!discountRate || !promoCode || !terms) {
+      toast({
+        title: "Validation Error",
+        description: "All fields are required.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      // Get the token from localStorage or your auth context
+      const token = localStorage.getItem("token"); // or get from your auth context
+
+      if (!token) {
+        throw new Error("Authentication required. Please log in again.");
+      }
+
+      const response = await fetch(
+        "http://localhost:4000/api/loyalty-partners/apply",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({
+            discountRate,
+            promoCode,
+            termsAndConditions: terms,
+            expiryDate,
+          }),
+        }
+      );
+
+      const data = await response.json().catch(() => ({})); // Handle non-JSON responses
+
+      if (!response.ok) {
+        // If the server returned an error message, use it, otherwise use a default message
+        const errorMessage =
+          data.message || `HTTP error! status: ${response.status}`;
+        throw new Error(errorMessage);
+      }
+
+      toast({
+        title: "Success",
+        description:
+          data.message ||
+          "You applied to the GUC Loyalty Program successfully!",
+      });
+      onOpenChange(false);
+    } catch (error: any) {
+      console.error("Error applying to loyalty program:", error);
+
+      // More specific error messages based on the error type
+      let errorMessage = "Failed to apply to the loyalty program";
+
+      if (error.message.includes("Failed to fetch")) {
+        errorMessage =
+          "Unable to connect to the server. Please check your internet connection.";
+      } else if (error.message) {
+        errorMessage = error.message;
+      }
+
+      toast({
+        title: "Error",
+        description: errorMessage,
+        variant: "destructive",
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Apply to GUC Loyalty Program</DialogTitle>
+          <DialogDescription>
+            Fill the form below to participate in the program.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="discountRate">Discount Rate (%)</Label>
+            <Input
+              id="discountRate"
+              type="number"
+              value={discountRate}
+              onChange={(e) => setDiscountRate(Number(e.target.value))}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="promoCode">Promo Code</Label>
+            <Input
+              id="promoCode"
+              value={promoCode}
+              onChange={(e) => setPromoCode(e.target.value)}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="terms">Terms and Conditions</Label>
+            <Textarea
+              id="terms"
+              value={terms}
+              onChange={(e) => setTerms(e.target.value)}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="expiryDate">Expiry Date</Label>
+            <Input
+              id="expiryDate"
+              type="date"
+              value={expiryDate}
+              onChange={(e) => setExpiryDate(e.target.value)}
+            />
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={isSubmitting}
+          >
+            Cancel
+          </Button>
+          <Button onClick={handleSubmit} disabled={isSubmitting}>
+            {isSubmitting ? "Submitting..." : "Apply"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client/src/components/VendorHeader.tsx
+++ b/client/src/components/VendorHeader.tsx
@@ -14,6 +14,9 @@ import ThemeToggle from "./ThemeToggle";
 import Logo from "./Logo";
 import ProfileMenu from "./ProfileMenu";
 import { useLocation } from "wouter";
+import { useState, useEffect } from "react";
+import { Gift } from "lucide-react";
+import LoyaltyProgramDialog from "./LoyaltyProgramDialog";
 
 interface VendorHeaderProps {
   onSearch?: (query: string) => void;
@@ -30,12 +33,26 @@ export default function VendorHeader({
 }: VendorHeaderProps) {
   const [, setLocation] = useLocation();
 
+  const [isLoyaltyDialogOpen, setIsLoyaltyDialogOpen] = useState(false);
+
+  // Check URL hash on component mount and when it changes
+  useEffect(() => {
+    const hash = window.location.hash.substring(1);
+    if (hash === "loyalty-program") {
+      setIsLoyaltyDialogOpen(true);
+    }
+  }, []);
+
   const handleTabClick = (tab: string) => {
     if (onTabChange) {
       onTabChange(tab);
     }
-    // Update URL hash
     window.location.hash = tab;
+  };
+
+  const handleLoyaltyProgramClick = () => {
+    window.location.hash = "loyalty-program";
+    setIsLoyaltyDialogOpen(true);
   };
 
   return (
@@ -124,8 +141,35 @@ export default function VendorHeader({
             <XCircle className="h-4 w-4" />
             Rejected Requests
           </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            className={`gap-2 ${window.location.hash === "#loyalty-program" ? "underline decoration-primary decoration-2" : ""}`}
+            onClick={handleLoyaltyProgramClick}
+            data-testid="button-nav-loyalty"
+          >
+            <Gift className="h-4 w-4" />
+            Loyalty Program
+          </Button>
         </div>
       </div>
+
+      <LoyaltyProgramDialog
+        open={isLoyaltyDialogOpen}
+        onOpenChange={(open) => {
+          setIsLoyaltyDialogOpen(open);
+          if (!open) {
+            // Remove the hash when closing the dialog
+            window.history.pushState(
+              "",
+              document.title,
+              window.location.pathname + window.location.search
+            );
+          } else {
+            window.location.hash = "loyalty-program";
+          }
+        }}
+      />
     </header>
   );
 }

--- a/server/src/features/loyaltyPartners/loyaltyPartner.controller.js
+++ b/server/src/features/loyaltyPartners/loyaltyPartner.controller.js
@@ -48,7 +48,7 @@ export const LoyaltyPartnerController = {
     }
   },
 
-  async cancel(req, res, next) {
+  async cancel(req, res) {
     try {
       const vendorId = req.user.id; // Get vendor ID from authenticated user
       const result = await LoyaltyPartnerService.cancelLoyaltyProgram(vendorId);

--- a/server/src/features/loyaltyPartners/loyaltyPartner.controller.js
+++ b/server/src/features/loyaltyPartners/loyaltyPartner.controller.js
@@ -47,4 +47,27 @@ export const LoyaltyPartnerController = {
       return res.status(500).json({ error: "Internal server error." });
     }
   },
+
+  async cancel(req, res, next) {
+    try {
+      const vendorId = req.user.id; // Get vendor ID from authenticated user
+      const result = await LoyaltyPartnerService.cancelLoyaltyProgram(vendorId);
+
+      res.status(200).json({
+        status: "success",
+        message: result.message,
+        cancelledAt: result.cancelledAt,
+      });
+    } catch (err) {
+      console.error("Error cancelling loyalty program:", err);
+
+      const statusCode = err.statusCode || 500;
+      const message = err.message || "Failed to cancel loyalty program";
+
+      res.status(statusCode).json({
+        status: "error",
+        message: message,
+      });
+    }
+  },
 };

--- a/server/src/features/loyaltyPartners/loyaltyPartner.controller.js
+++ b/server/src/features/loyaltyPartners/loyaltyPartner.controller.js
@@ -36,7 +36,7 @@ export const LoyaltyPartnerController = {
           .json({ status: "fail", message: "Duplicate entry detected." });
       }
       // Custom errors thrown in service (e.g., vendor already applied)
-      if (err.message === "You have already applied for the loyalty program.") {
+      if (err.message === "You already have an active loyalty program.") {
         return res.status(409).json({ status: "fail", message: err.message });
       }
 

--- a/server/src/features/loyaltyPartners/loyaltyPartner.controller.js
+++ b/server/src/features/loyaltyPartners/loyaltyPartner.controller.js
@@ -70,4 +70,26 @@ export const LoyaltyPartnerController = {
       });
     }
   },
+
+  async getStatus(req, res) {
+    try {
+      const vendorId = req.user.id; // Get vendor ID from authenticated user
+      const status = await LoyaltyPartnerService.getVendorStatus(vendorId);
+
+      res.status(200).json({
+        status: "success",
+        data: status,
+      });
+    } catch (err) {
+      console.error("Error getting vendor loyalty status:", err);
+
+      const statusCode = err.statusCode || 500;
+      const message = err.message || "Failed to get loyalty status";
+
+      res.status(statusCode).json({
+        status: "error",
+        message: message,
+      });
+    }
+  },
 };

--- a/server/src/features/loyaltyPartners/loyaltyPartner.model.js
+++ b/server/src/features/loyaltyPartners/loyaltyPartner.model.js
@@ -28,7 +28,6 @@ const loyaltyPartnerSchema = new mongoose.Schema(
 
 // Ensure promo code is unique across all vendors
 loyaltyPartnerSchema.index({ promoCode: 1 }, { unique: true });
-loyaltyPartnerSchema.index({ vendorId: 1 }, { unique: true });
 
 export const LoyaltyPartner = mongoose.model(
   "LoyaltyPartner",

--- a/server/src/features/loyaltyPartners/loyaltyPartner.model.js
+++ b/server/src/features/loyaltyPartners/loyaltyPartner.model.js
@@ -6,16 +6,14 @@ const loyaltyPartnerSchema = new mongoose.Schema(
       type: mongoose.Schema.Types.ObjectId,
       ref: "User",
       required: true,
-      unique: true,
     },
     vendorName: { type: String, required: true, trim: true }, // synced from User model if needed
 
     status: {
       type: String,
-      enum: ["pending", "verified", "rejected", "cancelled"],
-      default: "pending",
+      enum: ["active", "cancelled"],
+      default: "active",
     },
-
     // loyalty program fields
     discountRate: { type: Number, min: 0, max: 100, required: true },
     promoCode: { type: String, trim: true, required: true, unique: true },

--- a/server/src/features/loyaltyPartners/loyaltyPartner.route.js
+++ b/server/src/features/loyaltyPartners/loyaltyPartner.route.js
@@ -7,13 +7,21 @@ import { applyLoyaltyProgramSchema } from "./loyaltyPartner.validation.js";
 
 const router = express.Router();
 
-// POST /api/loyaltyPartner/apply
+// POST /api/loyalty-partners/apply
 router.post(
   "/apply",
   authMiddleware,
   role(["vendor"]),
   validate(applyLoyaltyProgramSchema),
   LoyaltyPartnerController.apply
+);
+
+// DELETE /api/loyalty-partners/cancel
+router.delete(
+  "/cancel",
+  authMiddleware,
+  role(["vendor"]),
+  LoyaltyPartnerController.cancel
 );
 
 export default router;

--- a/server/src/features/loyaltyPartners/loyaltyPartner.route.js
+++ b/server/src/features/loyaltyPartners/loyaltyPartner.route.js
@@ -24,4 +24,12 @@ router.delete(
   LoyaltyPartnerController.cancel
 );
 
+// GET /api/loyalty-partners/status
+router.get(
+  "/status",
+  authMiddleware,
+  role(["vendor"]),
+  LoyaltyPartnerController.getStatus
+);
+
 export default router;

--- a/server/src/features/loyaltyPartners/loyaltyPartner.service.js
+++ b/server/src/features/loyaltyPartners/loyaltyPartner.service.js
@@ -3,14 +3,34 @@ import { User } from "../users/user.model.js";
 
 export const LoyaltyPartnerService = {
   async applyLoyaltyProgram(vendorId, data) {
-    // Check if vendor already applied
-    const existing = await LoyaltyPartner.findOne({ vendorId });
+    // Check if vendor already has an active loyalty program
+    const existing = await LoyaltyPartner.findOne({
+      vendorId,
+      status: "active",
+    });
     if (existing) {
-      const err = new Error(
-        "You have already applied for the loyalty program."
-      );
+      const err = new Error("You already have an active loyalty program.");
       err.statusCode = 409;
       throw err;
+    }
+
+    // Check if vendor has a cancelled program and update it instead of creating new
+    const cancelledProgram = await LoyaltyPartner.findOne({
+      vendorId,
+      status: "cancelled",
+    });
+
+    if (cancelledProgram) {
+      // Update the cancelled program with new details
+      cancelledProgram.status = "active";
+      cancelledProgram.discountRate = data.discountRate;
+      cancelledProgram.promoCode = data.promoCode;
+      cancelledProgram.termsAndConditions = data.termsAndConditions;
+      cancelledProgram.expiryDate = data.expiryDate;
+      cancelledProgram.deletedAt = null; // Remove cancellation timestamp
+
+      await cancelledProgram.save();
+      return cancelledProgram;
     }
 
     // Optionally fetch vendor name from User model
@@ -39,7 +59,7 @@ export const LoyaltyPartnerService = {
     // Find the active loyalty program for the vendor
     const existing = await LoyaltyPartner.findOne({
       vendorId,
-      status: { $in: ["pending", "verified"] },
+      status: "active",
     });
 
     if (!existing) {
@@ -50,13 +70,31 @@ export const LoyaltyPartnerService = {
 
     // Update status to cancelled
     existing.status = "cancelled";
-    existing.deletedAt = new Date();
 
     await existing.save();
 
     return {
       message: "Successfully cancelled loyalty program participation",
       cancelledAt: existing.deletedAt,
+    };
+  },
+
+  async getVendorStatus(vendorId) {
+    const loyaltyPartner = await LoyaltyPartner.findOne({ vendorId });
+
+    if (!loyaltyPartner) {
+      return { hasParticipation: false, status: null };
+    }
+
+    return {
+      hasParticipation: true,
+      status: loyaltyPartner.status,
+      details: {
+        discountRate: loyaltyPartner.discountRate,
+        promoCode: loyaltyPartner.promoCode,
+        termsAndConditions: loyaltyPartner.termsAndConditions,
+        expiryDate: loyaltyPartner.expiryDate,
+      },
     };
   },
 };

--- a/server/src/features/loyaltyPartners/loyaltyPartner.service.js
+++ b/server/src/features/loyaltyPartners/loyaltyPartner.service.js
@@ -34,4 +34,29 @@ export const LoyaltyPartnerService = {
 
     return newApplication;
   },
+
+  async cancelLoyaltyProgram(vendorId) {
+    // Find the active loyalty program for the vendor
+    const existing = await LoyaltyPartner.findOne({
+      vendorId,
+      status: { $in: ["pending", "verified"] },
+    });
+
+    if (!existing) {
+      const err = new Error("No active loyalty program found to cancel.");
+      err.statusCode = 404;
+      throw err;
+    }
+
+    // Update status to cancelled
+    existing.status = "cancelled";
+    existing.deletedAt = new Date();
+
+    await existing.save();
+
+    return {
+      message: "Successfully cancelled loyalty program participation",
+      cancelledAt: existing.deletedAt,
+    };
+  },
 };

--- a/server/src/features/loyaltyPartners/loyaltyPartner.service.js
+++ b/server/src/features/loyaltyPartners/loyaltyPartner.service.js
@@ -75,7 +75,6 @@ export const LoyaltyPartnerService = {
 
     return {
       message: "Successfully cancelled loyalty program participation",
-      cancelledAt: existing.deletedAt,
     };
   },
 

--- a/server/src/features/loyaltyPartners/loyaltyPartner.validation.js
+++ b/server/src/features/loyaltyPartners/loyaltyPartner.validation.js
@@ -15,7 +15,7 @@ export const applyLoyaltyProgramSchema = Joi.object({
     "any.required": "Promo code is required.",
   }),
 
-  termsAndConditions: Joi.string().max(500).allow("").required().messages({
+  termsAndConditions: Joi.string().max(500).required().messages({
     "string.max": "Terms and conditions cannot exceed 500 characters.",
   }),
 


### PR DESCRIPTION
This PR implements backend functionality that allows vendors to cancel their participation in the GUC loyalty program. It introduces a new route, controller, and service method to handle cancellation requests securely and efficiently.

Key Changes:

Service Layer: Added a method to cancel an active loyalty program for a vendor. This method checks if the vendor has a pending or verified program, updates the status to “cancelled,” and records the cancellation timestamp.

Controller: Added a method to handle cancellation requests from authenticated vendors and return appropriate success or error responses.

Routes: Added a new protected DELETE endpoint /api/loyalty-partners/cancel accessible only to vendors.

Testing Instructions:

Use the DELETE endpoint with a valid vendor JWT token.

Verify that the loyalty program status updates to “cancelled” and the cancellation timestamp is recorded.

Test edge cases: vendor already cancelled, rejected vendors, missing or invalid JWT, and non-existent vendor records.