### PR TITLE
feat(events): filter out deleted workshops in getMyEvents function (REQ 37)

### DIFF
--- a/server/src/features/events/event.controller.js
+++ b/server/src/features/events/event.controller.js
@@ -306,6 +306,7 @@ export class EventsController {
       const events = await eventService.getEvents({
         eventType: "workshop",
         createdBy: userId,
+        deletedAt: null,
       });
 
       return res


### PR DESCRIPTION
This pull request introduces a small change to the `EventsController` to ensure that only non-deleted workshops are retrieved when fetching events created by a user.

- Added a filter for `deletedAt: null` in the call to `eventService.getEvents` to exclude deleted events when fetching workshops created by a user.

Found it out thanks to @JomanaMahmoud in PR (#184).