### PR TITLE
fix(users): add a partial constraint on the email and id for the users 

### DIFF
--- a/server/src/features/auth/auth.service.js
+++ b/server/src/features/auth/auth.service.js
@@ -29,13 +29,17 @@ export const signUpUser = async (data) => {
   }
 
   // ✅ Step 3: Check for duplicate email
-  const existingUser = await User.findOne({ email: data.email });
+  const existingUser = await User.findOne({
+    email: data.email,
+    status: { $ne: "deleted" },
+  });
   if (existingUser) throw new Error("This email is already registered.");
 
   // ✅ Step 4: Additional duplicate checks
   if (["student", "staff", "ta", "professor"].includes(normalizedRole)) {
     const existingId = await User.findOne({
       studentStaffId: data.studentStaffId,
+      status: { $ne: "deleted" },
     });
     if (existingId) throw new Error("This ID is already registered.");
   } else if (normalizedRole === "vendor") {

--- a/server/src/features/users/user.model.js
+++ b/server/src/features/users/user.model.js
@@ -15,12 +15,11 @@ const userSchema = new mongoose.Schema(
         return ["student", "staff", "ta", "professor"].includes(this.role);
       },
     },
-    email: { type: String, required: true, unique: true, index: true },
+    email: { type: String, required: true, index: true },
     password: { type: String, required: true },
 
     studentStaffId: {
       type: String,
-      unique: true,
       sparse: true,
       required: function () {
         return ["student", "staff", "ta", "professor"].includes(this.role);
@@ -85,6 +84,24 @@ userSchema.index({ firstName: 1 }); // Index for firstName search
 userSchema.index({ lastName: 1 }); // Index for lastName search
 userSchema.index({ firstName: 1, lastName: 1 }); // Compound index for full name search
 userSchema.index({ role: 1 }); // Index for role filtering
+// Unique email ONLY when status is not "deleted"
+userSchema.index(
+  { email: 1 },
+  {
+    unique: true,
+    partialFilterExpression: { status: { $ne: "deleted" } },
+  }
+);
+
+// Unique studentStaffId ONLY when status is not "deleted"
+userSchema.index(
+  { studentStaffId: 1 },
+  {
+    unique: true,
+    sparse: true,
+    partialFilterExpression: { status: { $ne: "deleted" } },
+  }
+);
 
 userSchema.methods.comparePassword = async function (password) {
   return bcrypt.compare(password, this.password);


### PR DESCRIPTION
This pull request updates how user uniqueness is enforced for `email` and `studentStaffId` fields, ensuring that deleted users do not block new registrations with the same identifiers. The changes also move uniqueness constraints from the schema definition to partial indexes, which improves handling of soft-deleted users.

**User uniqueness and soft-delete handling:**

* Updated the `signUpUser` service to check for existing users by `email` and `studentStaffId` only if their status is not `"deleted"`, preventing deleted users from blocking new registrations.
* Removed the `unique: true` constraint from the `email` and `studentStaffId` fields in the `userSchema`, delegating uniqueness enforcement to indexes instead.

**Database indexing improvements:**

* Added partial unique indexes for `email` and `studentStaffId` fields that only apply when the user's status is not `"deleted"`, allowing reuse of these identifiers after a user is deleted.