### PR TITLE
feat(facilities): filter out booked slots in getCourtSchedules method

### DIFF
--- a/server/src/features/facilities/facility.service.js
+++ b/server/src/features/facilities/facility.service.js
@@ -136,6 +136,14 @@ class FacilitiesServiceClass {
       if (slot) slot.status = "booked";
     }
 
+    // Filter out booked slots before returning
+    Object.keys(schedules).forEach((type) => {
+      schedules[type] = schedules[type].map((day) => ({
+        date: day.date,
+        slots: day.slots.filter((slot) => slot.status === "available"),
+      }));
+    });
+
     return schedules;
   }
 


### PR DESCRIPTION
This pull request updates the facility scheduling logic to improve the accuracy of available slot reporting. The main change ensures that only available slots are returned to the client after booking operations.

Facility slot filtering:

* After booking a slot, the code now filters out any slots with a status of `"booked"` before returning the schedules, so only slots with status `"available"` are included in the response.