### PR TITLE
Fix(platformBooths): added start and end date upon payment for booths and displayed them in events accordingly

### DIFF
--- a/client/src/components/EventCard.tsx
+++ b/client/src/components/EventCard.tsx
@@ -470,12 +470,7 @@ export default function EventCard({
                   <div className="flex items-start text-muted-foreground">
                     <Calendar className="mr-2 h-4 w-4 mt-0.5 flex-shrink-0" />
                     <div className="flex-1">
-                      {isPlatformBooth && durationWeeks ? (
-                        <div>
-                          Active for {durationWeeks} week
-                          {durationWeeks > 1 ? "s" : ""}
-                        </div>
-                      ) : startDate && endDate ? (
+                      {startDate && endDate ? (
                         <div>
                           {formatDate(startDate)}, {formatTime(startDate)} →{" "}
                           {formatDate(endDate)}, {formatTime(endDate)}
@@ -483,6 +478,11 @@ export default function EventCard({
                       ) : startDate ? (
                         <div>
                           {formatDate(startDate)}, {formatTime(startDate)}
+                        </div>
+                      ) : isPlatformBooth && durationWeeks ? (
+                        <div>
+                          Active for {durationWeeks} week
+                          {durationWeeks > 1 ? "s" : ""}
                         </div>
                       ) : null}
                     </div>

--- a/client/src/pages/EventsOfficeDashboard.tsx
+++ b/client/src/pages/EventsOfficeDashboard.tsx
@@ -1368,34 +1368,34 @@ export default function EventsOfficeDashboard() {
                                     : event.eventType || "academic"
                                 }
                                 date={
-                                  event.eventType === "platform_booth" &&
-                                  event.durationWeeks
-                                    ? `Active for ${event.durationWeeks} week${
-                                        event.durationWeeks > 1 ? "s" : ""
-                                      }`
-                                    : event.startDate
-                                      ? new Date(
-                                          event.startDate
-                                        ).toLocaleDateString("en-US", {
-                                          weekday: "short",
-                                          month: "long",
-                                          day: "numeric",
-                                          year: "numeric",
-                                        })
+                                  event.startDate
+                                    ? new Date(
+                                        event.startDate
+                                      ).toLocaleDateString("en-US", {
+                                        weekday: "short",
+                                        month: "long",
+                                        day: "numeric",
+                                        year: "numeric",
+                                      })
+                                    : event.eventType === "platform_booth" &&
+                                        event.durationWeeks
+                                      ? `Active for ${event.durationWeeks} week${
+                                          event.durationWeeks > 1 ? "s" : ""
+                                        }`
                                       : "TBA"
                                 }
                                 time={
-                                  event.eventType === "platform_booth" &&
-                                  event.durationWeeks
-                                    ? ""
-                                    : event.startDate
-                                      ? new Date(
-                                          event.startDate
-                                        ).toLocaleTimeString("en-US", {
-                                          hour: "2-digit",
-                                          minute: "2-digit",
-                                          hour12: true,
-                                        })
+                                  event.startDate
+                                    ? new Date(
+                                        event.startDate
+                                      ).toLocaleTimeString("en-US", {
+                                        hour: "2-digit",
+                                        minute: "2-digit",
+                                        hour12: true,
+                                      })
+                                    : event.eventType === "platform_booth" &&
+                                        event.durationWeeks
+                                      ? ""
                                       : "TBA"
                                 }
                                 location={

--- a/client/src/pages/EventsOfficeDashboard.tsx
+++ b/client/src/pages/EventsOfficeDashboard.tsx
@@ -148,14 +148,26 @@ export default function EventsOfficeDashboard() {
 
     const now = new Date();
     const isBoothEvent = event.eventType === "platform_booth";
-    // Booth events don't have endDate, so they're always considered "upcoming"
     let isUpcoming = false;
     let isPast = false;
 
     if (isBoothEvent) {
-      // Booth events are always considered upcoming
-      isUpcoming = true;
-      isPast = false;
+      // Platform booths now have startDate and endDate
+      // Check if both dates have passed
+      if (event.startDate && event.endDate) {
+        const eventStartDate = new Date(event.startDate);
+        const eventEndDate = new Date(event.endDate);
+        eventEndDate.setUTCHours(23, 59, 59, 999);
+        // Both start and end dates must have passed for it to be past
+        isPast =
+          eventStartDate.getTime() < now.getTime() &&
+          eventEndDate.getTime() < now.getTime();
+        isUpcoming = !isPast;
+      } else {
+        // If booth doesn't have dates yet, consider it upcoming
+        isUpcoming = true;
+        isPast = false;
+      }
     } else if (event.endDate) {
       const eventEndDate = new Date(event.endDate);
       eventEndDate.setUTCHours(23, 59, 59, 999);

--- a/client/src/pages/FavoritesPage.tsx
+++ b/client/src/pages/FavoritesPage.tsx
@@ -92,8 +92,18 @@ export default function FavoritesPage() {
     });
   };
 
-  const formatBoothDate = (durationWeeks: number) => {
-    return `Active for ${durationWeeks} week${durationWeeks > 1 ? "s" : ""}`;
+  const formatBoothDate = (event: any) => {
+    // If platform booth has startDate and endDate, show dates
+    if (event.startDate && event.endDate) {
+      const start = formatEventDate(event.startDate);
+      const end = formatEventDate(event.endDate);
+      return `${start} - ${end}`;
+    }
+    // Otherwise fall back to duration
+    if (event.durationWeeks) {
+      return `Active for ${event.durationWeeks} week${event.durationWeeks > 1 ? "s" : ""}`;
+    }
+    return "TBA";
   };
 
   const getCategoryFromEvent = (event: any): EventCategory => {
@@ -202,12 +212,12 @@ export default function FavoritesPage() {
                   title={event.name}
                   category={getCategoryFromEvent(event)}
                   date={
-                    isBoothEvent && event.durationWeeks
-                      ? formatBoothDate(event.durationWeeks)
+                    isBoothEvent
+                      ? formatBoothDate(event)
                       : formatEventDate(event.startDate)
                   }
                   time={
-                    isBoothEvent && event.durationWeeks
+                    isBoothEvent && !event.startDate
                       ? ""
                       : formatEventTime(event.startDate)
                   }

--- a/client/src/pages/MyEvents.tsx
+++ b/client/src/pages/MyEvents.tsx
@@ -122,8 +122,18 @@ export default function MyEvents() {
     });
   };
 
-  const formatBoothDate = (durationWeeks: number) => {
-    return `Active for ${durationWeeks} week${durationWeeks > 1 ? "s" : ""}`;
+  const formatBoothDate = (event: any) => {
+    // If platform booth has startDate and endDate, show dates
+    if (event.startDate && event.endDate) {
+      const start = formatEventDate(event.startDate);
+      const end = formatEventDate(event.endDate);
+      return `${start} - ${end}`;
+    }
+    // Otherwise fall back to duration
+    if (event.durationWeeks) {
+      return `Active for ${event.durationWeeks} week${event.durationWeeks > 1 ? "s" : ""}`;
+    }
+    return "TBA";
   };
 
   const handleCardClick = async (eventId: string) => {
@@ -184,12 +194,12 @@ export default function MyEvents() {
                     title={event.name}
                     category={event.eventType}
                     date={
-                      isBoothEvent && event.durationWeeks
-                        ? formatBoothDate(event.durationWeeks)
+                      isBoothEvent
+                        ? formatBoothDate(event)
                         : formatEventDate(event.startDate)
                     }
                     time={
-                      isBoothEvent && event.durationWeeks
+                      isBoothEvent && !event.startDate
                         ? ""
                         : formatEventTime(event.startDate)
                     }

--- a/client/src/pages/VendorRequests.tsx
+++ b/client/src/pages/VendorRequests.tsx
@@ -212,6 +212,14 @@ export default function VendorRequests() {
     ) {
       return request.event.name;
     }
+
+    // For platform booth applications that are pending (no event created yet),
+    // generate the event name from the vendor's information
+    if (request?.type === "booth" && !request.event) {
+      const vendorName = request?.createdBy?.companyName || "Vendor";
+      return `${vendorName}'s platform booth`;
+    }
+
     // If event is just an ID string or null/undefined, return N/A
     return "N/A";
   };

--- a/server/src/features/applications/application.service.js
+++ b/server/src/features/applications/application.service.js
@@ -288,43 +288,8 @@ class ApplicationServiceClass {
 
     let eventId = application.event;
 
-    // If approving a platform booth application, create the event and link it
-    if (
-      status === "approved" &&
-      application.type === "booth" &&
-      !application.event
-    ) {
-      const vendor = application.createdBy;
-      const eventName = `${
-        vendor.firstName || vendor.companyName || "Vendor"
-      }'s platform booth`;
-
-      // Calculate start and end dates based on approval time and duration
-      // Start date is when the application is accepted/approved
-      const startDate = new Date(); // Current timestamp when approved
-
-      // End date is start date plus the duration in weeks
-      const endDate = new Date(startDate);
-      endDate.setDate(endDate.getDate() + application.durationWeeks * 7);
-
-      const eventData = {
-        name: eventName,
-        eventType: "platform_booth",
-        boothSize: application.boothSize,
-        durationWeeks: application.durationWeeks,
-        locationPreference: application.locationPreference,
-        location: application.locationPreference, // Set location from locationPreference
-        startDate: startDate, // Set start date
-        endDate: endDate, // Set end date
-        attendees: application.attendees,
-        createdBy: vendor._id,
-        application: application._id,
-        status: "approved",
-      };
-
-      const createdEvent = await Event.create(eventData);
-      eventId = createdEvent._id;
-    }
+    // Note: Platform booth events are now created when payment is confirmed,
+    // not when the application is approved. See transaction.service.js confirmStripePayment method.
 
     // Now update the application status and event field atomically
     // When approving, set paymentStatus to "pending" (payment required)

--- a/server/src/features/events/event.controller.js
+++ b/server/src/features/events/event.controller.js
@@ -707,17 +707,23 @@ export class EventsController {
   }
 
   // GET /api/events/past - returns events whose endDate is before or equal to now
+  // For platform booths, both startDate and endDate must have passed
   async getPastEvents(req, res, next) {
     try {
       // Require authenticated user (role middleware on route will enforce role)
       if (!req.user) throw new ApiError(401, "Unauthorized");
 
+      // Use end of today for comparison so events ending today are included
       const now = new Date();
+      now.setHours(23, 59, 59, 999);
 
       // Use service.getEvents with a filter for events that have ended
+      // For platform booths, we need both startDate and endDate to have passed
       const events = await eventService.getEvents({
-        endDate: { $lte: now },
+        status: "approved",
         deletedAt: null,
+        endDate: { $lte: now }, // End date has passed
+        startDate: { $lte: now }, // Start date has also passed (for platform booths)
       });
 
       return res

--- a/server/src/features/events/event.service.js
+++ b/server/src/features/events/event.service.js
@@ -379,12 +379,14 @@ export const getUpcomingEventsService = async (
   includeVendors = false,
   userRole = null
 ) => {
+  // Use start of today for comparison so events starting today are included
   const now = new Date();
+  now.setHours(0, 0, 0, 0);
 
   const filter = {
     status: "approved",
     deletedAt: null,
-    startDate: { $gte: now }, // All events (including platform booths) must have startDate >= now
+    startDate: { $gte: now }, // All events (including platform booths) must have startDate >= today
   };
 
   // Filter out events where the user's role is restricted
@@ -408,12 +410,14 @@ export const getUpcomingEventsWithVendors = async (
   includeVendors = true,
   userRole = null
 ) => {
+  // Use start of today for comparison so events starting today are included
   const now = new Date();
+  now.setHours(0, 0, 0, 0);
 
   const filter = {
     status: "approved",
     deletedAt: null,
-    startDate: { $gte: now }, // All events (including platform booths) must have startDate >= now
+    startDate: { $gte: now }, // All events (including platform booths) must have startDate >= today
   };
 
   // Filter out events where the user's role is restricted
@@ -501,12 +505,14 @@ export const searchEvents = async ({
   professor,
 }) => {
   // Build a flexible filter - only search upcoming events like getUpcomingEventsService
-  // Platform booths should also respect startDate >= now, just like regular events
+  // Platform booths should also respect startDate >= today, just like regular events
+  // Use start of today for comparison so events starting today are included
   const now = new Date();
+  now.setHours(0, 0, 0, 0);
   const filter = {
     status: "approved",
     deletedAt: null,
-    startDate: { $gte: now }, // All events (including platform booths) must have startDate >= now
+    startDate: { $gte: now }, // All events (including platform booths) must have startDate >= today
   };
 
   // Additional filters will be added to $and array

--- a/server/src/features/transactions/transaction.service.js
+++ b/server/src/features/transactions/transaction.service.js
@@ -7,6 +7,7 @@ import {
   sendPaymentReceipt,
   sendVendorPaymentReceipt,
 } from "../auth/email.service.js";
+import NotificationService from "../notifications/notification.service.js";
 
 const stripe = new Stripe({ apiKey: process.env.STRIPE_SECRET_KEY });
 
@@ -196,6 +197,19 @@ export class TransactionService {
                 paymentStatus: "paid",
                 event: createdEvent._id,
               });
+
+              // Send notification about new platform booth event
+              try {
+                await NotificationService.notifyNewEvent(
+                  createdEvent,
+                  "platform_booth"
+                );
+              } catch (error) {
+                console.error(
+                  "Error sending platform booth event notification:",
+                  error
+                );
+              }
             } else {
               // For non-booth applications or booths that already have events, just update payment status
               await Application.findByIdAndUpdate(applicationId, {
@@ -288,6 +302,19 @@ export class TransactionService {
             paymentStatus: "paid",
             event: createdEvent._id,
           });
+
+          // Send notification about new platform booth event
+          try {
+            await NotificationService.notifyNewEvent(
+              createdEvent,
+              "platform_booth"
+            );
+          } catch (error) {
+            console.error(
+              "Error sending platform booth event notification:",
+              error
+            );
+          }
         } else {
           // For non-booth applications or booths that already have events, just update payment status
           await Application.findByIdAndUpdate(applicationId, {

--- a/server/src/features/transactions/transaction.service.js
+++ b/server/src/features/transactions/transaction.service.js
@@ -146,11 +146,63 @@ export class TransactionService {
       // Prevent updating if already completed
       if (transaction.status === "completed") {
         // Ensure application paymentStatus is set to "paid" if needed
+        // and create platform booth event if payment was just confirmed
         if (transaction.relatedEntity?.type === "Application") {
           const applicationId = transaction.relatedEntity.id;
-          await Application.findByIdAndUpdate(applicationId, {
-            paymentStatus: "paid",
-          });
+          const application =
+            await Application.findById(applicationId).populate("createdBy");
+
+          if (application) {
+            // If this is a platform booth application and event doesn't exist yet,
+            // create it with start date = payment confirmation date
+            if (
+              application.type === "booth" &&
+              application.paymentStatus !== "paid" &&
+              !application.event
+            ) {
+              const vendor = application.createdBy;
+              const eventName = `${
+                vendor.firstName || vendor.companyName || "Vendor"
+              }'s platform booth`;
+
+              // Start date is when payment is confirmed
+              const startDate = new Date();
+
+              // End date is start date plus the duration in weeks
+              const endDate = new Date(startDate);
+              endDate.setDate(
+                endDate.getDate() + application.durationWeeks * 7
+              );
+
+              const eventData = {
+                name: eventName,
+                eventType: "platform_booth",
+                boothSize: application.boothSize,
+                durationWeeks: application.durationWeeks,
+                locationPreference: application.locationPreference,
+                location: application.locationPreference,
+                startDate: startDate,
+                endDate: endDate,
+                attendees: application.attendees,
+                createdBy: vendor._id,
+                application: application._id,
+                status: "approved",
+              };
+
+              const createdEvent = await Event.create(eventData);
+
+              // Update application with event reference and payment status
+              await Application.findByIdAndUpdate(applicationId, {
+                paymentStatus: "paid",
+                event: createdEvent._id,
+              });
+            } else {
+              // For non-booth applications or booths that already have events, just update payment status
+              await Application.findByIdAndUpdate(applicationId, {
+                paymentStatus: "paid",
+              });
+            }
+          }
         }
         return { message: "Payment already confirmed", transaction };
       }
@@ -187,9 +239,66 @@ export class TransactionService {
       if (transaction.relatedEntity?.type === "Application") {
         // Update application paymentStatus to "paid"
         const applicationId = transaction.relatedEntity.id;
-        await Application.findByIdAndUpdate(applicationId, {
-          paymentStatus: "paid",
-        });
+        const application =
+          await Application.findById(applicationId).populate("createdBy");
+
+        if (!application) {
+          throw new Error("Application not found");
+        }
+
+        // If this is a platform booth application and payment is confirmed,
+        // create the event with start date = payment confirmation date
+        // and end date = start date + duration
+        if (
+          application.type === "booth" &&
+          application.paymentStatus !== "paid" &&
+          !application.event
+        ) {
+          const vendor = application.createdBy;
+          const eventName = `${
+            vendor.firstName || vendor.companyName || "Vendor"
+          }'s platform booth`;
+
+          // Start date is when payment is confirmed
+          const startDate = new Date();
+
+          // End date is start date plus the duration in weeks
+          const endDate = new Date(startDate);
+          endDate.setDate(endDate.getDate() + application.durationWeeks * 7);
+
+          const eventData = {
+            name: eventName,
+            eventType: "platform_booth",
+            boothSize: application.boothSize,
+            durationWeeks: application.durationWeeks,
+            locationPreference: application.locationPreference,
+            location: application.locationPreference,
+            startDate: startDate,
+            endDate: endDate,
+            attendees: application.attendees,
+            createdBy: vendor._id,
+            application: application._id,
+            status: "approved",
+          };
+
+          const createdEvent = await Event.create(eventData);
+
+          // Update application with event reference and payment status
+          await Application.findByIdAndUpdate(applicationId, {
+            paymentStatus: "paid",
+            event: createdEvent._id,
+          });
+        } else {
+          // For non-booth applications or booths that already have events, just update payment status
+          await Application.findByIdAndUpdate(applicationId, {
+            paymentStatus: "paid",
+          });
+        }
+
+        // Get the updated application for email
+        const updatedApplication = await Application.findById(applicationId)
+          .populate("event", "name location")
+          .populate("createdBy", "companyName");
 
         // Get Stripe receipt URL from the payment intent
         let stripeReceiptUrl = null;
@@ -209,20 +318,17 @@ export class TransactionService {
           // Continue without receipt URL - email will still be sent
         }
 
-        // Get vendor and application details for email
+        // Get vendor details for email
         const vendor = await User.findById(transaction.userId).select(
           "email firstName lastName name companyName role"
         );
-        const application = await Application.findById(applicationId)
-          .populate("event", "name location")
-          .populate("createdBy", "companyName");
 
         // Send vendor payment receipt email (don't await to avoid blocking the response)
-        if (vendor && application) {
+        if (vendor && updatedApplication) {
           sendVendorPaymentReceipt(
             vendor.toObject(),
             transaction,
-            application.toObject(),
+            updatedApplication.toObject(),
             stripeReceiptUrl
           ).catch(console.error);
         }


### PR DESCRIPTION
# Platform Booth Event Creation and Display Improvements

## Overview
This PR implements significant improvements to platform booth event lifecycle management, ensuring events are created only after payment confirmation and properly displayed across the application with accurate date information.

## Changes Made

### 1. Platform Booth Event Creation on Payment Confirmation
**Backend Changes:**
- **`server/src/features/applications/application.service.js`**
  - Removed event creation logic from `updateApplicationStatus` when approving platform booths
  - Events are no longer created at approval time; only `paymentStatus` is set to "pending"

- **`server/src/features/transactions/transaction.service.js`**
  - Added event creation logic in `confirmStripePayment` method
  - When payment is confirmed for a platform booth application:
    - **Start Date**: Set to payment confirmation date/time
    - **End Date**: Calculated as start date + duration (durationWeeks × 7 days)
  - Handles both normal payment flow and already-completed payment scenarios

### 2. Upcoming Events Query Fix
**Backend Changes:**
- **`server/src/features/events/event.service.js`**
  - Updated `getUpcomingEventsService` to normalize date comparison to start of day
  - Updated `getUpcomingEventsWithVendors` with same date normalization
  - Updated `searchEvents` to use start of day for consistent date filtering
  - Platform booths with start dates now properly appear in upcoming events

### 3. Past Events Query Enhancement
**Backend Changes:**
- **`server/src/features/events/event.controller.js`**
  - Updated `getPastEvents` to include platform booths where both start and end dates have passed
  - Added `status: "approved"` filter for consistency
  - Uses end of day for date comparison to include events ending today

**Frontend Changes:**
- **`client/src/pages/EventsOfficeDashboard.tsx`**
  - Updated client-side filtering to properly classify platform booths as past when both dates have passed

### 4. Vendor Requests Page Improvements
**Frontend Changes:**
- **`client/src/pages/VendorRequests.tsx`**
  - Updated `getEventName` function to display event name for pending platform booths
  - Shows `"{Company Name}'s platform booth"` for pending applications instead of "N/A"
  - Maintains consistency with event naming after payment confirmation

### 5. Event Card Display Updates
**Frontend Changes:**
- **`client/src/components/EventCard.tsx`**
  - Prioritizes displaying start/end dates for platform booths when available
  - Falls back to "Active for X weeks" only when dates are not set
  - 
- **`client/src/pages/MyEvents.tsx`**
  - Updated `formatBoothDate` to show date range when available
  - Falls back to duration text when dates are missing

- **`client/src/pages/EventsOfficeDashboard.tsx`**
  - Updated to show formatted dates for platform booths when available

- **`client/src/pages/FavoritesPage.tsx`**
  - Updated `formatBoothDate` to display dates when available

## Testing Instructions

### Test Scenario 1: Platform Booth Application Flow
1. **As a Vendor:**
   - Navigate to Vendor Dashboard
   - Apply for a platform booth (select booth size, duration, location preference)
   - Submit the application

2. **As Events Office/Admin:**
   - Navigate to Vendor Requests page (`/events-office/vendor-requests` or `/admin/vendor-requests`)
   - **Verify**: Pending platform booth shows event name as `"{Company Name}'s platform booth"` (not "N/A")
   - Approve the platform booth application
   - **Verify**: Application status changes to "approved", paymentStatus is "pending"
   - **Verify**: No event is created yet in the database (check upcoming events - booth should not appear)

3. **As a Vendor:**
   - Navigate to Vendor Dashboard → Approved Applications tab
   - Click "Pay Now" for the approved platform booth
   - Complete payment (use Stripe test card: 4242 4242 4242 4242)
   - **Verify**: Payment is confirmed successfully

4. **Verify Event Creation:**
   - Check database: Event should be created with:
     - `startDate` = payment confirmation timestamp
     - `endDate` = startDate + (durationWeeks × 7 days)
     - `eventType` = "platform_booth"
     - `status` = "approved"
   - Navigate to upcoming events page
   - **Verify**: Platform booth appears in upcoming events with correct dates

### Test Scenario 2: Upcoming Events Display
1. **As any user:**
   - Navigate to Home page or Upcoming Events page
   - **Verify**: Platform booths with start dates appear in the list
   - **Verify**: Date range is displayed (e.g., "Jan 15, 2024, 10:00 AM → Feb 5, 2024, 10:00 AM")
   - **Verify**: For upcoming booths, duration note appears below: "Active for 3 weeks" (in smaller, muted text)

2. **Test Date Filtering:**
   - Create a platform booth with payment today
   - **Verify**: It appears in upcoming events (events starting today should be included)
   - Create a platform booth with payment date in the past but end date in future
   - **Verify**: It appears in upcoming events

### Test Scenario 3: Past Events Display
1. **As Events Office/Admin:**
   - Create a platform booth application
   - Approve it
   - Complete payment
   - Manually update the event in database to have past start and end dates:
     ```javascript
     // In MongoDB or via API
     startDate: new Date('2024-01-01')
     endDate: new Date('2024-01-08') // 1 week duration
     ```
   - Navigate to Events Office Dashboard
   - Switch to "Past Events" filter
   - **Verify**: Platform booth appears in past events
   - **Verify**: Date range is displayed correctly

### Test Scenario 4: Event Card Display
1. **Test in Multiple Views:**
   - Navigate to:
     - Home page
     - My Events page (if registered)
     - Favorites page (if favorited)
     - Events Office Dashboard
     - Staff/TA Upcoming Events
   
2. **For each view, verify:**
   - Platform booths with dates show: "Start Date → End Date"
   - Platform booths without dates show: "Active for X weeks"
   - Upcoming platform booths show duration note below date range
   - Past platform booths do NOT show duration note

## Expected Behavior Summary
- ✅ Platform booth events created only after payment confirmation
- ✅ Start date = payment confirmation date
- ✅ End date = start date + duration
- ✅ Platform booths appear in upcoming events when start date >= today
- ✅ Platform booths appear in past events when both dates have passed
- ✅ Event name shows in vendor requests for pending booths
- ✅ Event cards display date ranges instead of duration when available
- ✅ Duration note appears under date range for upcoming booths only
