### PR TITLE
fix(NotFound): remove unused Header component from NotFound page

### DIFF
--- a/client/src/pages/not-found.tsx
+++ b/client/src/pages/not-found.tsx
@@ -9,7 +9,6 @@ export default function NotFound() {
 
   return (
     <div className="min-h-screen bg-background">
-      <Header />
       <div className="w-full flex items-center justify-center pt-20 px-4">
         <Card className="w-full max-w-lg mx-4 overflow-visible">
           <CardContent className="pt-12 pb-8 overflow-visible">


### PR DESCRIPTION
This pull request makes a small UI adjustment to the `NotFound` page by removing the header component.