### PR TITLE
fix(EventRegistration): update event registration flow to return updated MyEvents page

### DIFF
--- a/client/src/components/EventCard.tsx
+++ b/client/src/components/EventCard.tsx
@@ -282,13 +282,28 @@ export default function EventCard({
         });
         return;
       }
+      const data = await res.json().catch(() => null);
+
       toast({
         title: "Registered!",
         description: "You are now registered for this event.",
       });
 
+      // Update local UI state
       setRegistered(true);
       setLocalAttendeeCount((prev) => prev + 1);
+
+      // Dispatch a custom event so other parts of the app (e.g. MyEvents)
+      // can react and refetch their data if needed
+      try {
+        window.dispatchEvent(
+          new CustomEvent("event:registered", {
+            detail: { eventId: id, event: data?.event || null },
+          })
+        );
+      } catch (e) {
+        // ignore if dispatch not supported
+      }
     } catch {
       toast({
         title: "Error",

--- a/client/src/pages/MyEvents.tsx
+++ b/client/src/pages/MyEvents.tsx
@@ -101,6 +101,22 @@ export default function MyEvents() {
     };
 
     fetchEvents();
+
+    // Listen for registrations happening elsewhere in the app and refetch
+    const onRegistered = (e: any) => {
+      try {
+        // If the event was passed and user already has it, skip; otherwise refetch
+        fetchEvents();
+      } catch (err) {
+        // ignore
+      }
+    };
+
+    window.addEventListener("event:registered", onRegistered as any);
+
+    return () => {
+      window.removeEventListener("event:registered", onRegistered as any);
+    };
   }, []);
 
   // Fetch full event details by ID

--- a/server/src/features/events/event.controller.js
+++ b/server/src/features/events/event.controller.js
@@ -569,11 +569,16 @@ export class EventsController {
       const user = req.user; // expects at least { _id, role, ... }
       const eventId = req.params.id;
 
-      await eventService.registerUserToEvent(user, eventId);
+      const updatedEvent = await eventService.registerUserToEvent(
+        user,
+        eventId
+      );
 
-      return res
-        .status(200)
-        .json({ message: "Successfully registered for the event." });
+      // Return the updated event so the client can update UI without refetch
+      return res.status(200).json({
+        message: "Successfully registered for the event.",
+        event: updatedEvent,
+      });
     } catch (err) {
       // If the service threw an error object with statusCode, use it
       if (err && err.statusCode) {

--- a/server/src/features/events/event.service.js
+++ b/server/src/features/events/event.service.js
@@ -394,7 +394,13 @@ export const registerUserToEvent = async (user, eventId) => {
   event.attendees.push(user._id);
   await event.save();
 
-  return { message: "Successfully registered for the event." };
+  // Return the updated event document so callers can use it immediately
+  const updatedEvent = await Event.findById(eventId).populate(
+    "attendees",
+    "firstName lastName email role"
+  );
+
+  return updatedEvent;
 };
 
 export const getEventsByUser = async (userId) => {


### PR DESCRIPTION
fix(EventRegistration): update event registration flow to return updated event data and notify MyEvents page


EventRegistration: Update event registration flow to return updated event data and notify My Events page

Summary: Updated registration so the server returns the updated event object after a successful registration, and the client notifies the My Events page to refetch. This fixes a UI race where users saw a registration toast but the event did not appear in My Events.

Why: Previously the registration endpoint returned only a success message. The My Events page fetched user registrations only on mount, so registrations made elsewhere (or via payment flows) could be missed until a manual refresh. Returning the updated event and emitting a small client-side notification keeps the UI in sync immediately.