### PR TITLE
fix(NotificationsPopover): increase size of notifications badge for better visibility

### DIFF
--- a/client/src/components/NotificationsPopover.tsx
+++ b/client/src/components/NotificationsPopover.tsx
@@ -204,7 +204,7 @@ export default function NotificationsPopover() {
           >
             <Bell className="h-5 w-5" />
             {unreadCount > 0 && (
-              <span className="absolute top-0 right-0 h-4 w-4 bg-purple-600 rounded-full flex items-center justify-center text-[10px] font-bold text-white border-2 border-background">
+              <span className="absolute top-0 right-0 h-[18px] w-[18px] bg-purple-600 rounded-full flex items-center justify-center text-[10px] font-bold text-white border-[1.6px] border-background">
                 {unreadCount > 9 ? "9+" : unreadCount}
               </span>
             )}


### PR DESCRIPTION
This pull request makes a small UI adjustment to the notifications badge in the `NotificationsPopover` component. The badge size and border thickness have been slightly changed to improve visual consistency.

* Increased the badge size from `h-4 w-4` to `h-[18px] w-[18px]` and reduced border thickness from `border-2` to `border-[1.6px]` for the unread notifications indicator in `NotificationsPopover.tsx`.