### PR TITLE
fix(NotificationsPopover): remove system label from notification sender display

### DIFF
--- a/client/src/components/NotificationsPopover.tsx
+++ b/client/src/components/NotificationsPopover.tsx
@@ -365,20 +365,17 @@ export default function NotificationsPopover() {
                   </p>
                 </div>
                 <div className="text-right space-y-1">
-                  <div className="flex items-center gap-2 justify-end">
-                    <User className="h-4 w-4 text-muted-foreground" />
-                    <p className="text-sm font-medium">
-                      {selectedNotification.sender
-                        ? ["events_office", "admin"].includes(
-                            selectedNotification.sender.role
-                          )
-                          ? selectedNotification.sender.role
-                              .replace("_", " ")
-                              .toUpperCase()
-                          : `${selectedNotification.sender.firstName || ""} ${selectedNotification.sender.lastName || ""}`.trim()
-                        : "System"}
-                    </p>
-                  </div>
+                  <p className="text-sm font-medium">
+                    {selectedNotification.sender
+                      ? ["events_office", "admin"].includes(
+                          selectedNotification.sender.role
+                        )
+                        ? selectedNotification.sender.role
+                            .replace("_", " ")
+                            .toUpperCase()
+                        : `${selectedNotification.sender.firstName || ""} ${selectedNotification.sender.lastName || ""}`.trim()
+                      : ""}
+                  </p>
                 </div>
               </div>
 


### PR DESCRIPTION
This pull request makes a small UI adjustment to the `NotificationsPopover` component by simplifying the sender display logic and removing an unnecessary icon.

* UI simplification: Removed the `User` icon from the sender section and adjusted the logic to display an empty string instead of "System" when there is no sender, resulting in a cleaner and less cluttered notification popover. [[1]](diffhunk://#diff-8c6474ccd60ad9c3f4b82d3c94cf1080fe83b94a5bd7cf0575176e199b56da0fL368-L369) [[2]](diffhunk://#diff-8c6474ccd60ad9c3f4b82d3c94cf1080fe83b94a5bd7cf0575176e199b56da0fL379-L383)