### PR TITLE
feat(EventsReport): update event type display and conditionally render export options

### DIFF
--- a/client/src/components/EventsReport.tsx
+++ b/client/src/components/EventsReport.tsx
@@ -331,7 +331,9 @@ export default function EventsReport() {
                           {event.name}
                         </TableCell>
                         <TableCell className="capitalize">
-                          {event.eventType}
+                          {event.eventType === "platform_booth"
+                            ? "Platform Booth"
+                            : event.eventType}
                         </TableCell>
                         <TableCell>
                           {event.startDate
@@ -351,35 +353,37 @@ export default function EventsReport() {
                           {event.attendeesCount}
                         </TableCell>
                         <TableCell className="text-right">
-                          <DropdownMenu>
-                            <DropdownMenuTrigger asChild>
-                              <Button
-                                variant="ghost"
-                                size="sm"
-                                className="h-8 w-8 p-0"
-                              >
-                                <Download className="h-4 w-4" />
-                              </Button>
-                            </DropdownMenuTrigger>
-                            <DropdownMenuContent align="end">
-                              <DropdownMenuItem
-                                onClick={() =>
-                                  handleExport(event._id, event.name, "pdf")
-                                }
-                              >
-                                <Download className="mr-2 h-4 w-4" />
-                                Export as PDF
-                              </DropdownMenuItem>
-                              <DropdownMenuItem
-                                onClick={() =>
-                                  handleExport(event._id, event.name, "xlsx")
-                                }
-                              >
-                                <Download className="mr-2 h-4 w-4" />
-                                Export as XLSX
-                              </DropdownMenuItem>
-                            </DropdownMenuContent>
-                          </DropdownMenu>
+                          {event.eventType !== "conference" && (
+                            <DropdownMenu>
+                              <DropdownMenuTrigger asChild>
+                                <Button
+                                  variant="ghost"
+                                  size="sm"
+                                  className="h-8 w-8 p-0"
+                                >
+                                  <Download className="h-4 w-4" />
+                                </Button>
+                              </DropdownMenuTrigger>
+                              <DropdownMenuContent align="end">
+                                <DropdownMenuItem
+                                  onClick={() =>
+                                    handleExport(event._id, event.name, "pdf")
+                                  }
+                                >
+                                  <Download className="mr-2 h-4 w-4" />
+                                  Export as PDF
+                                </DropdownMenuItem>
+                                <DropdownMenuItem
+                                  onClick={() =>
+                                    handleExport(event._id, event.name, "xlsx")
+                                  }
+                                >
+                                  <Download className="mr-2 h-4 w-4" />
+                                  Export as XLSX
+                                </DropdownMenuItem>
+                              </DropdownMenuContent>
+                            </DropdownMenu>
+                          )}
                         </TableCell>
                       </TableRow>
                     ))}


### PR DESCRIPTION
This pull request updates the `EventsReport` component to improve the display and user interface for event types and actions. The most important changes include making the event type "platform_booth" more readable and conditionally showing the actions dropdown only for non-conference events.

**UI improvements for event types:**

* The event type "platform_booth" is now displayed as "Platform Booth" for better readability in the table.

**Conditional actions dropdown:**

* The actions dropdown menu is now only shown for events that are not of type "conference", reducing clutter and limiting actions to relevant event types. [[1]](diffhunk://#diff-933d0c1fbaae41cf516c8919576888bce8479e773b184a9471be07daecb539a3R356) [[2]](diffhunk://#diff-933d0c1fbaae41cf516c8919576888bce8479e773b184a9471be07daecb539a3R386)