### PR TITLE
fix(gymScheduleViewer): refresh sessions list after successful registration

### DIFF
--- a/client/src/components/GymScheduleViewer.tsx
+++ b/client/src/components/GymScheduleViewer.tsx
@@ -166,6 +166,7 @@ export default function GymScheduleViewer({
       title: "Success",
       description: "Successfully registered for the gym session.",
     });
+    fetchGymSessions(); // Refresh the sessions list
   };
 
   const handleEditClick = (session: GymSession) => {


### PR DESCRIPTION
This pull request introduces a small update to the `GymScheduleViewer` component to improve user experience after registering for a gym session.

* After a successful registration, the sessions list is now refreshed by calling `fetchGymSessions` to ensure the displayed data is up-to-date.