### PR TITLE
fix(EventFilters): add events prop to filter locations and professors dynamically

### DIFF
--- a/client/src/components/EventFilters.tsx
+++ b/client/src/components/EventFilters.tsx
@@ -49,6 +49,7 @@ interface EventFiltersProps {
   onSortChange?: (order: "asc" | "desc") => void;
   userRole?: string;
   onClear?: () => void;
+  events?: any[];
 }
 
 export default function EventFilters({
@@ -60,6 +61,7 @@ export default function EventFilters({
   onSortChange,
   userRole,
   onClear,
+  events,
 }: EventFiltersProps) {
   const today = useMemo(() => {
     const now = new Date();
@@ -67,10 +69,103 @@ export default function EventFilters({
     return now.toISOString().split("T")[0];
   }, []);
 
+  // ------------------------------------------------------------------
+  // 1. FILTER LOCATIONS (based on selected Professor)
+  // ------------------------------------------------------------------
   const locationOptions = useMemo(() => {
+    // If a professor is selected, filter available locations
+    if (
+      events &&
+      events.length > 0 &&
+      filters.professor &&
+      filters.professor !== "all"
+    ) {
+      const selectedProfId = String(filters.professor);
+
+      const professorEvents = events.filter((event) => {
+        // Check singular 'professor'
+        const pSingle =
+          event.professor?._id ||
+          event.professor?.id ||
+          event.professorId ||
+          event.professor;
+        if (pSingle && String(pSingle) === selectedProfId) return true;
+
+        // Check plural 'professors'
+        if (Array.isArray(event.professors)) {
+          return event.professors.some((p: any) => {
+            const pId = p?._id || p?.id || p;
+            return String(pId) === selectedProfId;
+          });
+        }
+        return false;
+      });
+
+      const uniqueFilteredLocations = Array.from(
+        new Set(
+          professorEvents
+            .map((e) => e.location || e.locationPreference)
+            .filter(Boolean)
+        )
+      );
+
+      return ["all", ...uniqueFilteredLocations];
+    }
+
+    // Default: Show all locations
     const unique = Array.from(new Set(locations.filter(Boolean)));
     return ["all", ...unique];
-  }, [locations]);
+  }, [locations, filters.professor, events]);
+
+  // ------------------------------------------------------------------
+  // 2. FILTER PROFESSORS (based on selected Location)
+  // ------------------------------------------------------------------
+  const filteredProfessors = useMemo(() => {
+    // If a location is selected, filter available professors
+    if (
+      events &&
+      events.length > 0 &&
+      filters.location &&
+      filters.location !== "all"
+    ) {
+      const selectedLocation = filters.location;
+      const relevantProfessorIds = new Set<string>();
+
+      // Find all events at this location
+      const locationEvents = events.filter(
+        (e) =>
+          e.location === selectedLocation ||
+          e.locationPreference === selectedLocation
+      );
+
+      // Extract professor IDs from these events
+      locationEvents.forEach((event) => {
+        // Check singular 'professor'
+        const pSingle =
+          event.professor?._id ||
+          event.professor?.id ||
+          event.professorId ||
+          event.professor;
+        if (pSingle) relevantProfessorIds.add(String(pSingle));
+
+        // Check plural 'professors'
+        if (Array.isArray(event.professors)) {
+          event.professors.forEach((p: any) => {
+            const pId = p?._id || p?.id || p;
+            if (pId) relevantProfessorIds.add(String(pId));
+          });
+        }
+      });
+
+      // Return only professors that exist in our relevant IDs set
+      return professors.filter((p) => relevantProfessorIds.has(String(p.id)));
+    }
+
+    // Default: Show all professors
+    return professors;
+  }, [professors, filters.location, events]);
+
+  // ------------------------------------------------------------------
 
   const updateFilters = (changes: Partial<EventFilterState>) => {
     onFilterChange({ ...filters, ...changes });
@@ -192,9 +287,9 @@ export default function EventFilters({
               </SelectTrigger>
               <SelectContent>
                 <SelectItem value="all">All professors</SelectItem>
-                {professors.length === 0
+                {filteredProfessors.length === 0
                   ? null
-                  : professors.map((p) => (
+                  : filteredProfessors.map((p) => (
                       <SelectItem key={p.id} value={p.id}>
                         {p.name}
                       </SelectItem>

--- a/client/src/pages/EventsOfficeDashboard.tsx
+++ b/client/src/pages/EventsOfficeDashboard.tsx
@@ -1284,6 +1284,7 @@ export default function EventsOfficeDashboard() {
                   professors={professorOptions}
                   userRole={userRole}
                   onClear={handleClearFilters}
+                  events={combinedEvents} // <--- ADDED THIS PROP
                 />
               </div>
             </aside>


### PR DESCRIPTION
This pull request enhances the event filtering logic in the `EventFilters` component to provide dynamic filtering of locations and professors based on user selections, improving the user experience and filter accuracy. The changes introduce new logic to filter location options by selected professor and filter professor options by selected location, ensuring only relevant choices are presented. Additionally, the component now receives the full list of events as a prop for context-aware filtering.

**Dynamic filtering enhancements:**

* Added logic to filter available locations based on the selected professor, showing only locations where the professor has events.
* Implemented logic to filter available professors based on the selected location, showing only professors who have events at that location.
* Updated the professor selection dropdown to use the dynamically filtered professor list, ensuring only relevant professors are shown.

**Prop and interface updates:**

* Added an `events` prop to the `EventFiltersProps` interface and passed the `combinedEvents` data to the `EventFilters` component, enabling context-aware filtering. [[1]](diffhunk://#diff-5793e5a841b1cc45fe2d3e285917b6cfb3f400406286e4b8acd55963e9a03e70R52) [[2]](diffhunk://#diff-3b80f2919b2d59e50b1c65c33bea9c96bbc509a42efeb7792c9946a13e0f055aR1287)