### PR TITLE
fix(transactions-events): i can cancel a registeration that i didnt pay for so i will just not get refunded

### DIFF
--- a/server/src/features/events/event.model.js
+++ b/server/src/features/events/event.model.js
@@ -18,7 +18,9 @@ const eventSchema = new Schema(
     location: {
       type: String,
       required: function () {
-        return this.eventType !== "platform_booth";
+        return (
+          this.eventType !== "platform_booth" && this.eventType !== "conference"
+        );
       },
     },
     startDate: {

--- a/server/src/features/events/event.service.js
+++ b/server/src/features/events/event.service.js
@@ -1550,8 +1550,6 @@ export const cancelEventRegistration = async (eventId, userId) => {
   const twoWeeksBefore = new Date(event.startDate);
   twoWeeksBefore.setDate(twoWeeksBefore.getDate() - 14);
 
-  console.log("twoWeeksBefore:", twoWeeksBefore);
-  console.log("now:", now);
   if (now > twoWeeksBefore) {
     throw new ApiError(
       400,

--- a/server/src/features/events/event.service.js
+++ b/server/src/features/events/event.service.js
@@ -1550,6 +1550,8 @@ export const cancelEventRegistration = async (eventId, userId) => {
   const twoWeeksBefore = new Date(event.startDate);
   twoWeeksBefore.setDate(twoWeeksBefore.getDate() - 14);
 
+  console.log("twoWeeksBefore:", twoWeeksBefore);
+  console.log("now:", now);
   if (now > twoWeeksBefore) {
     throw new ApiError(
       400,

--- a/server/src/features/events/event.service.js
+++ b/server/src/features/events/event.service.js
@@ -1569,15 +1569,27 @@ export const cancelEventRegistration = async (eventId, userId) => {
   );
   await event.save();
 
-  // Refund logic
-  const refund = await transactionService.refundUserForEvent(userId, event._id);
-
-  return {
-    eventId,
-    refundedAmount: refund.amount,
-    paymentMethod: refund.paymentMethod,
-    transactionId: refund._id,
-  };
+  // Only process refund if event has a price
+  if (event.price && !isNaN(event.price) && Number(event.price) > 0) {
+    const refund = await transactionService.refundUserForEvent(
+      userId,
+      event._id
+    );
+    return {
+      eventId,
+      refundedAmount: refund.amount,
+      paymentMethod: refund.paymentMethod,
+      transactionId: refund._id,
+    };
+  } else {
+    return {
+      eventId,
+      refundedAmount: 0,
+      paymentMethod: null,
+      transactionId: null,
+      message: "No refund issued as event has no price.",
+    };
+  }
 };
 
 export const restrictAccess = async (eventId, rolesToRestrict, user) => {

--- a/server/src/features/events/event.validation.js
+++ b/server/src/features/events/event.validation.js
@@ -210,12 +210,6 @@ export const createWorkshopSchema = Joi.object({
       "array.min": "Professors list must contain at least one ID",
       "string.hex": "Professor IDs must be valid ObjectIds",
     }),
-
-  price: Joi.number().positive().required().messages({
-    "any.required": "Workshop price is required",
-    "number.base": "Price must be a number",
-    "number.positive": "Price must be a positive number",
-  }),
 });
 
 export const updateWorkshopSchema = Joi.object({

--- a/server/src/features/transactions/transaction.service.js
+++ b/server/src/features/transactions/transaction.service.js
@@ -28,16 +28,29 @@ export class TransactionService {
   }
 
   async payForEvent({ userId, eventId, paymentMethod }) {
-    // Check if user already paid for this event
-    const existingTransaction = await Transaction.findOne({
+    // Check if user already paid for this event and hasn't been refunded
+    const existingPayment = await Transaction.findOne({
       userId,
       "relatedEntity.type": "Event",
       "relatedEntity.id": eventId,
       status: "completed",
       type: "payment",
     });
-    if (existingTransaction) {
-      throw new Error("You have already paid for this event.");
+
+    if (existingPayment) {
+      // Check if there is a completed refund for this payment
+      const refundExists = await Transaction.findOne({
+        userId,
+        "relatedEntity.type": "Event",
+        "relatedEntity.id": eventId,
+        status: "completed",
+        type: "refund",
+      });
+
+      if (!refundExists) {
+        throw new Error("You have already paid for this event.");
+      }
+      // If refund exists, allow payment to proceed
     }
 
     // Fetch event and ensure user is registered
@@ -461,15 +474,29 @@ export class TransactionService {
   }
 
   async payForApplication({ userId, applicationId, paymentMethod }) {
-    const existingTransaction = await Transaction.findOne({
+    // Check if user already paid for this application and hasn't been refunded
+    const existingPayment = await Transaction.findOne({
       userId,
       "relatedEntity.type": "Application",
       "relatedEntity.id": applicationId,
       status: "completed",
       type: "payment",
     });
-    if (existingTransaction) {
-      throw new Error("You have already paid for this application.");
+
+    if (existingPayment) {
+      // Check if there is a completed refund for this payment
+      const refundExists = await Transaction.findOne({
+        userId,
+        "relatedEntity.type": "Application",
+        "relatedEntity.id": applicationId,
+        status: "completed",
+        type: "refund",
+      });
+
+      if (!refundExists) {
+        throw new Error("You have already paid for this application.");
+      }
+      // If refund exists, allow payment to proceed
     }
 
     const application = await Application.findById(applicationId)

--- a/server/src/features/transactions/transaction.service.js
+++ b/server/src/features/transactions/transaction.service.js
@@ -474,7 +474,7 @@ export class TransactionService {
   }
 
   async payForApplication({ userId, applicationId, paymentMethod }) {
-    // Check if user already paid for this application and hasn't been refunded
+    // Check if user already paid for this application
     const existingPayment = await Transaction.findOne({
       userId,
       "relatedEntity.type": "Application",
@@ -484,19 +484,8 @@ export class TransactionService {
     });
 
     if (existingPayment) {
-      // Check if there is a completed refund for this payment
-      const refundExists = await Transaction.findOne({
-        userId,
-        "relatedEntity.type": "Application",
-        "relatedEntity.id": applicationId,
-        status: "completed",
-        type: "refund",
-      });
-
-      if (!refundExists) {
-        throw new Error("You have already paid for this application.");
-      }
-      // If refund exists, allow payment to proceed
+      // No refunds for applications, so block re-payment
+      throw new Error("You have already paid for this application.");
     }
 
     const application = await Application.findById(applicationId)


### PR DESCRIPTION
This pull request introduces several important updates to event registration, payment, and refund logic. The changes improve validation and error handling for event payments and refunds, including more robust checks for prior payments and refunds, and adjustments to required fields for events and workshops.

**Payment and Refund Logic Improvements**
* Updated `payForEvent` and `payForApplication` in `transaction.service.js` to allow payments only if a prior payment has been refunded, preventing duplicate payments unless a refund exists. [[1]](diffhunk://#diff-c41a5c0ed004b00ab8fc8de02a453eddabca84e55ee97f7abfc9fde349c7a585L31-R54) [[2]](diffhunk://#diff-c41a5c0ed004b00ab8fc8de02a453eddabca84e55ee97f7abfc9fde349c7a585L464-R500)
* Modified refund handling in `cancelEventRegistration` in `event.service.js` to only process a refund if the event has a price greater than zero, returning a message when no refund is issued.

**Validation and Schema Adjustments**
* Changed the `location` field requirement in `event.model.js` so it is not required for both `platform_booth` and `conference` event types.
* Removed the requirement for the `price` field in the `createWorkshopSchema` in `event.validation.js`, making workshop price optional.

**Debugging and Logging**
* Added console logs to `cancelEventRegistration` in `event.service.js` to help debug the refund deadline calculation.