### PR TITLE
fix(Router): enforce role-based access for workshop and bazaar creation routes

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -94,7 +94,6 @@ function Router() {
           <AdminUsers />
         </ProtectedRoute>
       </Route>
-      <Route path="/create/workshop" component={CreateWorkshop} />
       <Route path="/professor">
         <ProtectedRoute allowedRoles={["professor"]}>
           <ProfessorDashboard />
@@ -141,7 +140,11 @@ function Router() {
         </ProtectedRoute>
       </Route>
 
-      <Route path="/create/bazaar" component={CreateBazaar} />
+      <Route path="/create/bazaar">
+        <ProtectedRoute allowedRoles={["events_office"]}>
+          <CreateBazaar />
+        </ProtectedRoute>
+      </Route>
       <Route path="/vendor/dashboard">
         <ProtectedRoute allowedRoles={["vendor"]}>
           <VendorDashboard />
@@ -199,13 +202,16 @@ function Router() {
         </ProtectedRoute>
       </Route>
 
-      <Route path="/approvals/workshops" component={WorkshopApprovals} />
       <Route path="/vendor-requests">
         <ProtectedRoute allowedRoles={["admin", "events_office"]}>
           <VendorRequests />
         </ProtectedRoute>
       </Route>
-      <Route path="/events" component={EventListPage} />
+      <Route path="/events">
+        <ProtectedRoute allowedRoles={["admin", "events_office"]}>
+          <EventListPage />
+        </ProtectedRoute>
+      </Route>
 
       <Route path="/favorites">
         <ProtectedRoute allowedRoles={["student", "staff", "ta", "professor"]}>


### PR DESCRIPTION
This pull request updates route protection in the `client/src/App.tsx` file to improve access control for several pages. The main changes involve wrapping certain routes with the `ProtectedRoute` component and specifying allowed user roles, ensuring that only authorized users can access those pages.

**Access control improvements:**

* Wrapped the `/create/bazaar` route with `ProtectedRoute` and restricted access to users with the `events_office` role.
* Wrapped the `/events` route with `ProtectedRoute`, allowing only `admin` and `events_office` users to access the `EventListPage`.

**Route removals:**

* Removed the `/create/workshop` and `/approvals/workshops` routes, which previously allowed unrestricted access to `CreateWorkshop` and `WorkshopApprovals` components. [[1]](diffhunk://#diff-ce931a2269184f4b06d6be36ead81f2ca3e95e44a5c8d600f47da1dfa35b9337L97) [[2]](diffhunk://#diff-ce931a2269184f4b06d6be36ead81f2ca3e95e44a5c8d600f47da1dfa35b9337L202-R214)