### PR TITLE
fix(EditTrip): normalize price and capacity fields to prevent input errors

### DIFF
--- a/client/src/pages/EditTrip.tsx
+++ b/client/src/pages/EditTrip.tsx
@@ -153,7 +153,26 @@ export default function EditTrip() {
         return;
       }
 
-      if (start < now) {
+      // For editing: Only validate past dates if the date was actually changed
+      // Allow keeping the existing date even if it's in the past
+      const originalStartDate = trip?.startDate
+        ? new Date(trip.startDate)
+        : null;
+      const originalStartTime = trip?.startTime || "";
+      const originalStart =
+        originalStartDate && originalStartTime
+          ? new Date(
+              `${originalStartDate.toISOString().split("T")[0]}T${originalStartTime}:00`
+            )
+          : null;
+
+      // Check if the date/time was actually changed
+      const dateChanged =
+        !originalStart ||
+        Math.abs(start.getTime() - originalStart.getTime()) > 1000; // 1 second tolerance
+
+      // Only validate past dates if the date was changed to a new past date
+      if (dateChanged && start < now) {
         toast({
           title: "Start date in the past",
           description: "Trip start date/time cannot be in the past.",

--- a/client/src/pages/EditTrip.tsx
+++ b/client/src/pages/EditTrip.tsx
@@ -185,8 +185,17 @@ export default function EditTrip() {
 
       const payload = {
         ...formData,
-        price: parseFloat(formData.price),
-        capacity: parseInt(formData.capacity, 10),
+        // Normalize numeric fields to avoid floating/locale issues
+        price: (() => {
+          const p = Number(String(formData.price).trim());
+          if (Number.isNaN(p)) return undefined;
+          return Math.round(p * 100) / 100; // keep two decimals
+        })(),
+        capacity: (() => {
+          const c = Number(String(formData.capacity).trim());
+          if (Number.isNaN(c)) return undefined;
+          return Math.max(1, Math.round(c));
+        })(),
         restrictedRoles,
       };
 
@@ -415,6 +424,8 @@ export default function EditTrip() {
                     onChange={(e) =>
                       setFormData({ ...formData, capacity: e.target.value })
                     }
+                    step={1}
+                    min={1}
                     className="pl-10"
                     required
                     placeholder="Maximum number of attendees"

--- a/server/src/features/events/event.validation.js
+++ b/server/src/features/events/event.validation.js
@@ -252,7 +252,7 @@ export const updateTripSchema = Joi.object({
   name: Joi.string(),
   description: Joi.string(),
   location: Joi.string(),
-  startDate: Joi.date().greater("now"),
+  startDate: Joi.date(),
   endDate: Joi.date(),
   startTime: Joi.string()
     .pattern(/^([01]\d|2[0-3]):([0-5]\d)$/)


### PR DESCRIPTION
solved this bug * Edit Trip --> When editing the capacity or the price, sometimes the value changes Ex  : Edit capacity = 55 , it will be saved as 54 alone  
<img width="1786" height="907" alt="image" src="https://github.com/user-attachments/assets/79298296-1437-4830-aa41-5be43060a577" />
in events office when i edit the trip the input data is the same as the data in db