### PR TITLE
ui: avoid premature 'no events' message on feedback page by waiting for feedback checks

### DIFF
--- a/client/src/pages/FeedbackDashboard.tsx
+++ b/client/src/pages/FeedbackDashboard.tsx
@@ -70,6 +70,8 @@ export default function FeedbackDashboard() {
   useEffect(() => {
     // Fetch both upcoming and past events so we include any event
     setLoadingEvents(true);
+
+    // First get upcoming + past, then for the deduped list fetch feedback for each
     Promise.allSettled([api.get("/events/upcoming"), api.get("/events/past")])
       .then((results) => {
         const combined: any[] = [];
@@ -106,47 +108,41 @@ export default function FeedbackDashboard() {
             return true;
           });
 
-        // For each mapped event, check whether it has any feedback and
-        // only keep events that have at least one feedback item.
-        Promise.allSettled(
+        // Return the inner Promise so the outer chain waits for feedback checks
+        return Promise.allSettled(
           mapped.map((m: any) => api.get(`/feedback/events/${m.id}`))
-        )
-          .then((fbResults) => {
-            const eventsWithFeedback = mapped
-              .map((m: any, idx: number) => {
-                const res = fbResults[idx];
-                if (res.status !== "fulfilled") return null;
-                const data = (res as any).value?.data?.data;
-                const feedback = data?.feedback || [];
-                if (!Array.isArray(feedback) || feedback.length === 0) {
-                  return null;
-                }
-
-                return {
-                  ...m,
-                  averageRating: data?.averageRating || 0,
-                  totalReviews: data?.totalReviews || feedback.length,
-                };
-              })
-              .filter((e): e is EventItem => e !== null);
-
-            setEvents(eventsWithFeedback);
-            setSelectedEvent((prev) => {
-              if (
-                prev &&
-                eventsWithFeedback.some(
-                  (eventWithFeedback) => eventWithFeedback.id === prev
-                )
-              ) {
-                return prev;
+        ).then((fbResults) => {
+          const eventsWithFeedback = mapped
+            .map((m: any, idx: number) => {
+              const res = fbResults[idx];
+              if (res.status !== "fulfilled") return null;
+              const data = (res as any).value?.data?.data;
+              const feedback = data?.feedback || [];
+              if (!Array.isArray(feedback) || feedback.length === 0) {
+                return null;
               }
-              return null;
-            });
-          })
-          .catch(() => {
-            setEvents([]);
-          })
-          .finally(() => setLoadingEvents(false));
+
+              return {
+                ...m,
+                averageRating: data?.averageRating || 0,
+                totalReviews: data?.totalReviews || feedback.length,
+              };
+            })
+            .filter((e): e is EventItem => e !== null);
+
+          setEvents(eventsWithFeedback);
+          setSelectedEvent((prev) => {
+            if (
+              prev &&
+              eventsWithFeedback.some(
+                (eventWithFeedback) => eventWithFeedback.id === prev
+              )
+            ) {
+              return prev;
+            }
+            return null;
+          });
+        });
       })
       .catch(() => setEvents([]))
       .finally(() => setLoadingEvents(false));


### PR DESCRIPTION
This pull request refactors the event and feedback fetching logic in the `FeedbackDashboard` component to improve promise chaining and error handling. The main change is restructuring how feedback is fetched for events to ensure the outer promise chain waits for all feedback checks before proceeding.

**Improvements to asynchronous data fetching:**

* Changed the feedback fetching logic to return the inner `Promise.allSettled` so the outer chain properly waits for all feedback checks before continuing. This helps prevent race conditions and ensures events are only processed after their feedback has been checked.
* Updated comments to clarify the new flow: first fetch upcoming and past events, then dedupe and fetch feedback for each event.

**Error handling and loading state:**

* Simplified error handling and loading state management by moving the `.catch` and `.finally` blocks to the outer promise chain, ensuring consistent behavior when errors occur or loading finishes.