### PR TITLE
ui: adjust discount badge dark-mode shade and border opacity

### DIFF
--- a/client/src/pages/ApprovedLoyaltyPartnersPage.tsx
+++ b/client/src/pages/ApprovedLoyaltyPartnersPage.tsx
@@ -249,7 +249,7 @@ export default function ApprovedLoyaltyPartnersPage() {
                         <TableCell className="px-4">
                           <Badge
                             variant="secondary"
-                            className="bg-green-100 text-green-800"
+                            className="bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300 border-green-200 dark:border-green-700/50"
                           >
                             {partner.discountRate}% OFF
                           </Badge>


### PR DESCRIPTION
This pull request makes a minor UI improvement to the display of the discount badge on the `ApprovedLoyaltyPartnersPage`. The change enhances dark mode support for the badge styling.

* Improved dark mode styling for the discount rate badge by adding dark theme background, text, and border classes in `ApprovedLoyaltyPartnersPage.tsx`.