### PR TITLE
feat: enhance date formatting for start and end times in CreateEventForm and CreateConference

### DIFF
--- a/client/src/components/CreateEventForm.tsx
+++ b/client/src/components/CreateEventForm.tsx
@@ -181,7 +181,9 @@ export default function CreateEventForm({
 
     // Logical date/time validation
     if (values.startDate && values.startTime) {
-      const start = new Date(`${values.startDate}T${values.startTime}:00`);
+      const start = new Date(
+        `${format(values.startDate, "yyyy-MM-dd")}T${values.startTime}:00`
+      );
       const now = new Date();
       if (!isNaN(start.getTime()) && start < now) {
         nextErrors.startTime = "Start date/time cannot be in the past";
@@ -198,8 +200,12 @@ export default function CreateEventForm({
       values.endDate &&
       values.endTime
     ) {
-      const start = new Date(`${values.startDate}T${values.startTime}:00`);
-      const end = new Date(`${values.endDate}T${values.endTime}:00`);
+      const start = new Date(
+        `${format(values.startDate, "yyyy-MM-dd")}T${values.startTime}:00`
+      );
+      const end = new Date(
+        `${format(values.endDate, "yyyy-MM-dd")}T${values.endTime}:00`
+      );
       if (!isNaN(start.getTime()) && !isNaN(end.getTime()) && end <= start) {
         // Attach error to end time for clarity
         nextErrors.endTime = "End date/time must be after start date/time";

--- a/client/src/components/EventFilters.tsx
+++ b/client/src/components/EventFilters.tsx
@@ -349,15 +349,14 @@ export default function EventFilters({
                   <Button
                     variant={"outline"}
                     className={cn(
-                      "w-full justify-start text-left font-normal text-sm h-9 px-2",
+                      "w-full justify-center text-center font-normal text-sm h-9 px-2",
                       !filters.startDate && "text-muted-foreground"
                     )}
                   >
-                    <CalendarIcon className="mr-0.5 h-3.5 w-3.5" />
                     {filters.startDate ? (
                       format(filters.startDate, "dd/MM/yyyy")
                     ) : (
-                      <span className="text-xs">dd/mm/yyyy</span>
+                      <span className="text-sm">dd/mm/yyyy</span>
                     )}
                   </Button>
                 </PopoverTrigger>
@@ -388,15 +387,14 @@ export default function EventFilters({
                   <Button
                     variant={"outline"}
                     className={cn(
-                      "w-full justify-start text-left font-normal text-sm h-9 px-2",
+                      "w-full justify-center text-center font-normal text-sm h-9 px-2",
                       !filters.endDate && "text-muted-foreground"
                     )}
                   >
-                    <CalendarIcon className="mr-0.5 h-3.5 w-3.5" />
                     {filters.endDate ? (
                       format(filters.endDate, "dd/MM/yyyy")
                     ) : (
-                      <span className="text-xs">dd/mm/yyyy</span>
+                      <span className="text-sm">dd/mm/yyyy</span>
                     )}
                   </Button>
                 </PopoverTrigger>

--- a/client/src/pages/CreateConference.tsx
+++ b/client/src/pages/CreateConference.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { format } from "date-fns";
 import EventsOfficeHeader from "@/components/EventsOfficeHeader";
 import CreateEventForm, {
   CreateEventFormValues,
@@ -34,8 +35,12 @@ export default function CreateConference() {
 
       const payload: any = {
         name: values.name,
-        startDate: `${values.startDate}T${startTimeValue}:00.000Z`,
-        endDate: `${values.endDate}T${endTimeValue}:00.000Z`,
+        startDate: values.startDate
+          ? `${format(values.startDate, "yyyy-MM-dd")}T${startTimeValue}:00.000Z`
+          : "",
+        endDate: values.endDate
+          ? `${format(values.endDate, "yyyy-MM-dd")}T${endTimeValue}:00.000Z`
+          : "",
         startTime: startTimeValue, // Required by backend model
         endTime: endTimeValue, // Required by backend model
         description: values.description,


### PR DESCRIPTION
This pull request improves the way dates are handled and formatted in the event creation flow to ensure consistency and prevent potential bugs with date parsing. The most important changes are focused on using the `date-fns` library's `format` function to standardize date strings before constructing `Date` objects and sending them to the backend.

**Date formatting and validation improvements:**

* Updated date construction in `CreateEventForm` to use `format(values.startDate, "yyyy-MM-dd")` and `format(values.endDate, "yyyy-MM-dd")` before combining with time strings, ensuring correct and consistent date parsing for validation logic. [[1]](diffhunk://#diff-b96a62bc767c5d28448fc4f744c1c7e98df3c7dd62c71af85a749729122e9a13L184-R186) [[2]](diffhunk://#diff-b96a62bc767c5d28448fc4f744c1c7e98df3c7dd62c71af85a749729122e9a13L201-R208)
* Modified the payload construction in `CreateConference` to use formatted date strings for `startDate` and `endDate` when sending data to the backend, preventing issues with date serialization.
* Added import of `format` from `date-fns` in `CreateConference.tsx` to support the above changes.