### PR TITLE
feat: add Sentry screen replay integration for enhanced error tracking

### DIFF
--- a/client/src/instrument.ts
+++ b/client/src/instrument.ts
@@ -5,7 +5,17 @@ const dsn = import.meta.env.VITE_SENTRY_DSN as string | undefined;
 if (dsn) {
   Sentry.init({
     dsn,
+    enabled: import.meta.env.PROD,
     environment: import.meta.env.MODE,
     release: import.meta.env.VITE_SENTRY_RELEASE,
+    integrations: [
+      Sentry.replayIntegration({
+        maskAllText: true,
+        blockAllMedia: true,
+      }),
+    ],
+    // Record replays only when an error happens (best signal, lowest volume).
+    replaysSessionSampleRate: 0.0,
+    replaysOnErrorSampleRate: 1.0,
   });
 }


### PR DESCRIPTION
This pull request updates the Sentry initialization logic to improve error monitoring and privacy protections in the client application. The changes ensure Sentry is only enabled in production, add session replay integration with privacy safeguards, and configure replay sampling rates for efficiency.

Sentry configuration improvements:

* Sentry is now enabled only in production environments by checking `import.meta.env.PROD`.
* Added the Sentry Replay integration with `maskAllText` and `blockAllMedia` enabled to enhance user privacy during session recording.
* Configured replay sampling to record sessions only when an error occurs (`replaysSessionSampleRate: 0.0`, `replaysOnErrorSampleRate: 1.0`) to reduce unnecessary data collection.