### PR TITLE
Fix court bookings frontend: disable past slots and improve badge themes

### DIFF
--- a/client/src/pages/SportsFacilities.tsx
+++ b/client/src/pages/SportsFacilities.tsx
@@ -315,6 +315,19 @@ export default function SportsFacilities() {
 
   const renderCourtContent = () => {
     const bodyDate = getBodyDateFromIndex(currentDayIndex);
+    const now = new Date();
+    const currentHour = now.getHours();
+
+    const isSlotPast = (slotTime: string) => {
+      if (currentDayIndex > 0) return false;
+      const [timeStr, period] = slotTime.split(" ");
+      let [hoursStr] = timeStr.split(":");
+      let hours = parseInt(hoursStr);
+      if (period === "PM" && hours !== 12) hours += 12;
+      if (period === "AM" && hours === 12) hours = 0;
+      return hours <= currentHour;
+    };
+
     return (
       <div className="space-y-6">
         <div className="flex items-center justify-center gap-4 my-6">
@@ -399,12 +412,14 @@ export default function SportsFacilities() {
                             slot.startTime
                           );
                           const isReserving = reservingKeys.includes(slotKey);
+                          const isPast = isSlotPast(slot.startTime);
+
                           return (
                             <Button
                               key={slotKey}
                               variant="outline"
                               className="w-full justify-start gap-2 min-h-12 py-3"
-                              disabled={isReserving}
+                              disabled={isReserving || isPast}
                               onClick={() =>
                                 handleReserveCourt(
                                   type as CourtType,
@@ -420,7 +435,16 @@ export default function SportsFacilities() {
                                   </div>
                                 </div>
                                 <div>
-                                  <Badge>Available</Badge>
+                                  <Badge
+                                    variant={isPast ? "secondary" : "default"}
+                                    className={
+                                      isPast
+                                        ? "bg-muted text-muted-foreground hover:bg-muted"
+                                        : "hover:bg-primary/80"
+                                    }
+                                  >
+                                    {isPast ? "Unavailable" : "Available"}
+                                  </Badge>
                                 </div>
                               </div>
                             </Button>


### PR DESCRIPTION
This pull request updates the sports facilities reservation UI to prevent users from reserving time slots that have already passed for the current day. It introduces logic to determine whether a slot is in the past and updates both the button and badge display accordingly.

**Reservation logic improvements:**

* Added a new `isSlotPast` function to check if a slot's start time is earlier than the current hour for the current day, preventing reservation of past slots.
* Updated the slot reservation button to be disabled if the slot is either already being reserved or has passed.

**UI feedback enhancements:**

* Changed the badge for past slots to display "Unavailable" with muted styling, while future slots continue to show "Available".