### PR TITLE
Fix/disable edit button for started bazaars

### DIFF
--- a/client/src/components/EventCard.tsx
+++ b/client/src/components/EventCard.tsx
@@ -1900,7 +1900,7 @@ export default function EventCard({
                 e.preventDefault();
                 executeCancellation();
               }}
-              className="bg-red-600 hover:bg-red-700 text-white"
+              className="bg-red-600 hover:bg-red-700 text-white focus-visible:ring-0 border-0"
             >
               {isCanceling ? "Canceling..." : "Yes, Cancel"}
             </AlertDialogAction>

--- a/client/src/components/EventCard.tsx
+++ b/client/src/components/EventCard.tsx
@@ -160,6 +160,7 @@ export interface EventCardProps {
   onUnarchive?: () => void;
   isUnarchiving?: boolean;
   onEdit?: () => void;
+  editDisabled?: boolean;
   canDelete?: boolean;
   className?: string;
   allowCancellation?: boolean;
@@ -205,6 +206,7 @@ export default function EventCard({
   onUnarchive,
   isUnarchiving = false,
   onEdit,
+  editDisabled = false,
   canDelete = false,
   status,
   className,
@@ -1069,6 +1071,7 @@ export default function EventCard({
                       <Button
                         className="flex-1 order-2"
                         onClick={() => onEdit()}
+                        disabled={editDisabled}
                         data-testid={`button-edit-${id}`}
                       >
                         <Edit className="h-4 w-4 mr-1" />

--- a/client/src/components/EventsDetailsDialog.tsx
+++ b/client/src/components/EventsDetailsDialog.tsx
@@ -79,8 +79,21 @@ export default function EventDetailsDialog({
     });
   };
 
+  const formatStringTime = (timeStr?: string) => {
+    if (!timeStr) return null;
+    if (/^\d{1,2}:\d{2}$/.test(timeStr)) {
+      const [hoursStr, minutesStr] = timeStr.split(":");
+      let hours = parseInt(hoursStr, 10);
+      const suffix = hours >= 12 ? "PM" : "AM";
+      hours = hours % 12;
+      hours = hours ? hours : 12;
+      return `${hours}:${minutesStr} ${suffix}`;
+    }
+    return timeStr;
+  };
+
   const startTime =
-    event.startTime ||
+    formatStringTime(event.startTime) ||
     (event.startDate
       ? new Date(event.startDate).toLocaleTimeString("en-US", {
           hour: "2-digit",
@@ -88,7 +101,7 @@ export default function EventDetailsDialog({
         })
       : null);
   const endTime =
-    event.endTime ||
+    formatStringTime(event.endTime) ||
     (event.endDate
       ? new Date(event.endDate).toLocaleTimeString("en-US", {
           hour: "2-digit",

--- a/client/src/pages/EventsOfficeDashboard.tsx
+++ b/client/src/pages/EventsOfficeDashboard.tsx
@@ -1433,6 +1433,32 @@ export default function EventsOfficeDashboard() {
                             eventEndDate &&
                             eventEndDate.getTime() < now.getTime();
 
+                          // Check if event has started (for disabling edit)
+                          let isStarted = false;
+                          if (event.eventType === "trip" && event.startDate) {
+                            const tripStartDate = new Date(event.startDate);
+                            if (tripStartDate <= now) {
+                              isStarted = true;
+                            }
+                          } else if (
+                            event.eventType === "bazaar" &&
+                            event.startDate
+                          ) {
+                            const bazaarStart = new Date(event.startDate);
+                            if (
+                              event.startTime &&
+                              /^\d{1,2}:\d{2}$/.test(event.startTime)
+                            ) {
+                              const [h, m] = event.startTime
+                                .split(":")
+                                .map(Number);
+                              bazaarStart.setHours(h, m, 0, 0);
+                            }
+                            if (bazaarStart <= now) {
+                              isStarted = true;
+                            }
+                          }
+
                           return (
                             <div key={event._id || index} className="h-full">
                               <EventCard
@@ -1514,6 +1540,7 @@ export default function EventsOfficeDashboard() {
                                 onDelete={() => handleDeleteEvent(event._id)}
                                 hideRegisterButton={true}
                                 onViewDetails={() => handleCardClick(event._id)}
+                                editDisabled={isStarted}
                                 {...(isPastEvent
                                   ? {
                                       onArchive: () =>
@@ -1525,7 +1552,8 @@ export default function EventsOfficeDashboard() {
                                         "conference",
                                         "bazaar",
                                         "workshop",
-                                      ].includes(event.eventType)
+                                      ].includes(event.eventType) &&
+                                      userRole === "events_office"
                                     ? {
                                         onEdit: () => {
                                           if (event.eventType === "workshop") {
@@ -1554,13 +1582,51 @@ export default function EventsOfficeDashboard() {
                                             setLocation(
                                               `/events-office/events/trip/edit/${event._id}`
                                             );
+                                          } else if (
+                                            event.eventType === "bazaar"
+                                          ) {
+                                            if (event.startDate) {
+                                              const now = new Date();
+                                              const bazaarStart = new Date(
+                                                event.startDate
+                                              );
+
+                                              if (
+                                                event.startTime &&
+                                                /^\d{1,2}:\d{2}$/.test(
+                                                  event.startTime
+                                                )
+                                              ) {
+                                                const [h, m] = event.startTime
+                                                  .split(":")
+                                                  .map(Number);
+                                                bazaarStart.setHours(
+                                                  h,
+                                                  m,
+                                                  0,
+                                                  0
+                                                );
+                                              }
+
+                                              if (bazaarStart <= now) {
+                                                toast({
+                                                  title: "Cannot Edit Bazaar",
+                                                  description:
+                                                    "Cannot edit a bazaar that has already started.",
+                                                  variant: "destructive",
+                                                });
+                                                return;
+                                              }
+                                            }
+                                            setLocation(
+                                              `/create/bazaar?id=${event._id}`
+                                            );
                                           } else {
                                             const editRoutes: Record<
                                               string,
                                               string
                                             > = {
                                               conference: `/events-office/events/conference/edit/${event._id}`,
-                                              bazaar: `/create/bazaar?id=${event._id}`,
                                             };
                                             const route =
                                               editRoutes[event.eventType];

--- a/client/src/pages/WorkshopApprovals.tsx
+++ b/client/src/pages/WorkshopApprovals.tsx
@@ -326,14 +326,27 @@ export default function WorkshopApprovals() {
   const endDateStr = selectedWorkshop
     ? formatWorkshopDate(selectedWorkshop.endDate)
     : "";
+  const formatStringTime = (timeStr?: string) => {
+    if (!timeStr) return null;
+    if (/^\d{1,2}:\d{2}$/.test(timeStr)) {
+      const [hoursStr, minutesStr] = timeStr.split(":");
+      let hours = parseInt(hoursStr, 10);
+      const suffix = hours >= 12 ? "PM" : "AM";
+      hours = hours % 12;
+      hours = hours ? hours : 12;
+      return `${hours}:${minutesStr} ${suffix}`;
+    }
+    return timeStr;
+  };
+
   const startTimeStr = selectedWorkshop
-    ? selectedWorkshop.startTime ||
+    ? formatStringTime(selectedWorkshop.startTime) ||
       (selectedWorkshop.startDate
         ? formatWorkshopTime(selectedWorkshop.startDate)
         : "")
     : "";
   const endTimeStr = selectedWorkshop
-    ? selectedWorkshop.endTime ||
+    ? formatStringTime(selectedWorkshop.endTime) ||
       (selectedWorkshop.endDate
         ? formatWorkshopTime(selectedWorkshop.endDate)
         : "")


### PR DESCRIPTION
This pull request introduces improvements to event editing logic and time formatting across several components. The main focus is on preventing edits to events that have already started, enhancing user feedback, and ensuring consistent time display formats.

**Event editing restrictions and feedback:**

* Added logic to `EventsOfficeDashboard` to determine if an event has started (for both "trip" and "bazaar" types) and to disable the edit button accordingly by setting the new `editDisabled` prop in `EventCard`. Attempting to edit a started bazaar now shows a descriptive error toast. [[1]](diffhunk://#diff-3b80f2919b2d59e50b1c65c33bea9c96bbc509a42efeb7792c9946a13e0f055aR1436-R1461) [[2]](diffhunk://#diff-3b80f2919b2d59e50b1c65c33bea9c96bbc509a42efeb7792c9946a13e0f055aR1543) [[3]](diffhunk://#diff-3b80f2919b2d59e50b1c65c33bea9c96bbc509a42efeb7792c9946a13e0f055aR1585-L1563)
* Restricted edit permissions for certain event types to users with the "events_office" role.

**Component and UI updates:**

* Updated the `EventCard` component to accept and use the new `editDisabled` prop, disabling the edit button when appropriate. [[1]](diffhunk://#diff-d8a4d7a8b5e065f72a04e4c7670a25d9a7a752c1a16f504fbe4f01b26e8430e7R163) [[2]](diffhunk://#diff-d8a4d7a8b5e065f72a04e4c7670a25d9a7a752c1a16f504fbe4f01b26e8430e7R209) [[3]](diffhunk://#diff-d8a4d7a8b5e065f72a04e4c7670a25d9a7a752c1a16f504fbe4f01b26e8430e7R1074)
* Improved button styling for cancellation confirmation to remove focus ring and border for better UI consistency.

**Time formatting consistency:**

* Added a reusable `formatStringTime` function to format time strings (e.g., "13:00" to "1:00 PM") in both `EventDetailsDialog` and `WorkshopApprovals`, ensuring consistent time display throughout the UI. [[1]](diffhunk://#diff-4d00a3f0bbe1224c95a258209966ff0a8bd51848d979625c9dfd65978c7fa568R82-R104) [[2]](diffhunk://#diff-ea9d69fb073b133fddecb08982834c4c49e3c1c1f953ab4dd25f4347f3d599a5R329-R349)