### PR TITLE
Fix Give Feedback button logic and remove Reapply from vendor rejected requests

### DIFF
--- a/client/src/components/EventCard.tsx
+++ b/client/src/components/EventCard.tsx
@@ -709,6 +709,41 @@ export default function EventCard({
   };
 
   const now = new Date();
+
+  const parseEventDateForComparison = (
+    dateString?: string,
+    boundary: "start" | "end" = "start"
+  ) => {
+    if (!dateString) return null;
+
+    const ymdMatch = /^(\d{4})-(\d{2})-(\d{2})$/.exec(dateString);
+    if (ymdMatch) {
+      const year = Number(ymdMatch[1]);
+      const monthIndex = Number(ymdMatch[2]) - 1;
+      const day = Number(ymdMatch[3]);
+      const hours = boundary === "end" ? 23 : 0;
+      const minutes = boundary === "end" ? 59 : 0;
+      const seconds = boundary === "end" ? 59 : 0;
+      const ms = boundary === "end" ? 999 : 0;
+      return new Date(year, monthIndex, day, hours, minutes, seconds, ms);
+    }
+
+    const parsed = new Date(dateString);
+    return Number.isNaN(parsed.getTime()) ? null : parsed;
+  };
+
+  // Feedback should only be available for past events.
+  // Prefer endDate when available; for date-only strings, compare against end-of-day.
+  const feedbackComparisonDate =
+    parseEventDateForComparison(endDate ?? startDate, "end") ??
+    parseEventDateForComparison(startDate, "end");
+  const canShowFeedbackAction = Boolean(
+    onFeedback &&
+      registered &&
+      feedbackComparisonDate &&
+      now > feedbackComparisonDate
+  );
+
   const deadline = registrationDeadline ? new Date(registrationDeadline) : null;
   const isBeforeDeadline = !deadline || now <= deadline;
   const hasCapacity = !capacity || localAttendeeCount < capacity;
@@ -989,7 +1024,7 @@ export default function EventCard({
 
               {/* ACTION BUTTONS (Detailed View) */}
               <div className="flex gap-2 mt-auto w-full">
-                {registered && startDate && new Date() > new Date(startDate) ? (
+                {canShowFeedbackAction ? (
                   <>
                     <div className="flex gap-2 flex-1 justify-center">
                       <Button
@@ -1386,9 +1421,7 @@ export default function EventCard({
 
               {showActions && (
                 <div className="flex flex-col gap-2 pt-2 mt-auto">
-                  {registered &&
-                  startDate &&
-                  new Date() > new Date(startDate) ? (
+                  {canShowFeedbackAction ? (
                     <>
                       <div className="flex gap-2 w-full items-center">
                         <Button

--- a/client/src/pages/VendorDashboard.tsx
+++ b/client/src/pages/VendorDashboard.tsx
@@ -57,7 +57,6 @@ import ApplicationPaymentDialog from "@/components/ApplicationPaymentDialog";
 import IdUploadButton from "@/components/IdUploadButton";
 import { bazaarApiService, Application, Bazaar } from "@/lib/bazaarApi";
 import { useToast } from "@/hooks/use-toast";
-import { useLocation } from "wouter";
 
 interface Attendee {
   name: string;
@@ -66,7 +65,6 @@ interface Attendee {
 }
 
 export default function VendorDashboard() {
-  const [_location, _setLocation] = useLocation();
   const [showApplyDialog, setShowApplyDialog] = useState(false);
   const [selectedBazaar, setSelectedBazaar] = useState<Bazaar | null>(null);
   const [upcomingBazaars, setUpcomingBazaars] = useState<Bazaar[]>([]);
@@ -84,7 +82,7 @@ export default function VendorDashboard() {
   >([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [searchTerm, setSearchTerm] = useState("");
+  const [searchTerm, _setSearchTerm] = useState("");
   const [companyName, setCompanyName] = useState("");
 
   // Platform booth form state
@@ -93,10 +91,8 @@ export default function VendorDashboard() {
   >([{ name: "", email: "" }]);
   const [boothSize, setBoothSize] = useState<"2x2" | "4x4">("2x2");
   const [durationWeeks, setDurationWeeks] = useState<number>(1);
-  const [_locationPreference, _setLocationPreference] = useState<string>("");
   const [selectedMapLocation, setSelectedMapLocation] = useState<string>("");
-  const [_isSubmittingPlatformBooth, setIsSubmittingPlatformBooth] =
-    useState(false);
+  const [, setIsSubmittingPlatformBooth] = useState(false);
 
   // Booth application dialog state
   const [boothApplicationOpen, setBoothApplicationOpen] = useState(false);
@@ -150,10 +146,6 @@ export default function VendorDashboard() {
   };
 
   // Handle search functionality
-  const _handleSearch = (query: string) => {
-    setSearchTerm(query);
-  };
-
   // Filter data based on search term
   const getFilteredData = (data: any[], searchFields: string[]) => {
     if (!searchTerm) return data;

--- a/client/src/pages/VendorDashboard.tsx
+++ b/client/src/pages/VendorDashboard.tsx
@@ -190,7 +190,7 @@ export default function VendorDashboard() {
 
   const registeredBazaarIds = useMemo(() => {
     // A vendor is considered "registered" for a bazaar if they have an
-    // active application (pending/approved). Rejected applications can reapply.
+    // active application (pending/approved).
     const activeApplications = [
       ...pendingApplications,
       ...approvedApplications,
@@ -389,7 +389,6 @@ export default function VendorDashboard() {
 
   const handleRegister = (bazaarId: string) => {
     // Check if user has already applied to this bazaar (excluding rejected applications)
-    // Users should be able to reapply if their application was rejected
     const activeApplications = [
       ...pendingApplications,
       ...approvedApplications,
@@ -1395,8 +1394,7 @@ export default function VendorDashboard() {
                 <h1 className="text-4xl font-bold">Rejected Applications</h1>
               </div>
               <p className="text-muted-foreground">
-                Applications that were not approved. You can review and reapply
-                if needed.
+                Applications that were not approved.
               </p>
             </div>
             <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
@@ -1479,13 +1477,7 @@ export default function VendorDashboard() {
                           )}
                         </div>
                       </div>
-                      <Button
-                        variant="outline"
-                        className="w-full"
-                        data-testid={`button-reapply-${application._id}`}
-                      >
-                        Reapply
-                      </Button>
+                      {/* Reapply action intentionally removed */}
                     </CardContent>
                   </Card>
                 ))


### PR DESCRIPTION
This pull request introduces improvements to how event feedback actions are displayed in the `EventCard` component, ensuring feedback is only available for past events with accurate date comparisons. Additionally, it updates the vendor dashboard to remove the ability for users to reapply to rejected applications and clarifies related UI and comments.

**Event Feedback Action Improvements:**

* Added a helper function `parseEventDateForComparison` to accurately determine if an event is in the past, considering both date-only and datetime strings, and preferring `endDate` when available. This ensures feedback actions are only shown for past events.
* Updated conditional rendering for feedback actions in `EventCard` to use the new `canShowFeedbackAction` logic, improving accuracy and maintainability. [[1]](diffhunk://#diff-d8a4d7a8b5e065f72a04e4c7670a25d9a7a752c1a16f504fbe4f01b26e8430e7L992-R1027) [[2]](diffhunk://#diff-d8a4d7a8b5e065f72a04e4c7670a25d9a7a752c1a16f504fbe4f01b26e8430e7L1389-R1424)

**Vendor Dashboard Updates:**

* Removed the "Reapply" button and associated UI from the rejected applications section, so users can no longer reapply after rejection.
* Updated comments and help text to reflect that reapplying to rejected applications is no longer supported. [[1]](diffhunk://#diff-e4ce1a1e2a4027b2defffae6b3bda742cdb7d546dacc873c05b1a8f63996b493L193-R193) [[2]](diffhunk://#diff-e4ce1a1e2a4027b2defffae6b3bda742cdb7d546dacc873c05b1a8f63996b493L392) [[3]](diffhunk://#diff-e4ce1a1e2a4027b2defffae6b3bda742cdb7d546dacc873c05b1a8f63996b493L1398-R1397)