### PR TITLE
feat: add showShareButton prop to EventCard and update FavoritesPage to handle event times

### DIFF
--- a/client/src/components/EventCard.tsx
+++ b/client/src/components/EventCard.tsx
@@ -147,6 +147,7 @@ export interface EventCardProps {
   vendors?: Vendor[];
   price?: number;
   showActions?: boolean;
+  showShareButton?: boolean;
   showDetailedView?: boolean;
   showAttendees?: boolean;
   showRegisterButton?: boolean;
@@ -196,6 +197,7 @@ export default function EventCard({
   registrationDeadline,
   vendors = [],
   showActions = true,
+  showShareButton = true,
   showDetailedView = false,
   showAttendees = true,
   showRegisterButton = true,
@@ -1685,7 +1687,7 @@ export default function EventCard({
                               <FavoriteButton eventId={id} />
                             </div>
                           )}
-                          {inlineShareButton && (
+                          {showShareButton && inlineShareButton && (
                             <div className="order-4">
                               <ShareButton />
                             </div>
@@ -1742,7 +1744,7 @@ export default function EventCard({
                     </Button>
                   )}
 
-                  {!inlineShareButton && (
+                  {showShareButton && !inlineShareButton && (
                     <div className="flex items-center gap-2 ml-auto">
                       <ShareButton />
                     </div>

--- a/client/src/components/EventsDetailsDialog.tsx
+++ b/client/src/components/EventsDetailsDialog.tsx
@@ -94,20 +94,40 @@ export default function EventDetailsDialog({
 
   const startTime =
     formatStringTime(event.startTime) ||
-    (event.startDate
-      ? new Date(event.startDate).toLocaleTimeString("en-US", {
-          hour: "2-digit",
-          minute: "2-digit",
-        })
-      : null);
+    (() => {
+      if (!event.startDate) return null;
+      const date = new Date(event.startDate);
+      if (
+        date.getHours() === 0 &&
+        date.getMinutes() === 0 &&
+        date.getSeconds() === 0
+      ) {
+        return null;
+      }
+      return date.toLocaleTimeString("en-US", {
+        hour: "2-digit",
+        minute: "2-digit",
+        hour12: true,
+      });
+    })();
   const endTime =
     formatStringTime(event.endTime) ||
-    (event.endDate
-      ? new Date(event.endDate).toLocaleTimeString("en-US", {
-          hour: "2-digit",
-          minute: "2-digit",
-        })
-      : null);
+    (() => {
+      if (!event.endDate) return null;
+      const date = new Date(event.endDate);
+      if (
+        date.getHours() === 0 &&
+        date.getMinutes() === 0 &&
+        date.getSeconds() === 0
+      ) {
+        return null;
+      }
+      return date.toLocaleTimeString("en-US", {
+        hour: "2-digit",
+        minute: "2-digit",
+        hour12: true,
+      });
+    })();
 
   const startDateStr = formatDate(event.startDate);
   const endDateStr = formatDate(event.endDate);

--- a/client/src/lib/favoritesApi.ts
+++ b/client/src/lib/favoritesApi.ts
@@ -8,6 +8,8 @@ export interface FavoriteEvent {
   location: string;
   startDate: string;
   endDate: string;
+  startTime?: string;
+  endTime?: string;
   bannerImage?: string;
   status: string;
   eventType?: string;

--- a/client/src/pages/FavoritesPage.tsx
+++ b/client/src/pages/FavoritesPage.tsx
@@ -83,6 +83,47 @@ export default function FavoritesPage() {
     });
   };
 
+  // Convert a stored 24-hour time string (e.g. "14:05") to 12-hour ("2:05 PM")
+  const formatStringTime = (timeStr?: string) => {
+    if (!timeStr) return null;
+    if (/^\d{1,2}:\d{2}$/.test(timeStr)) {
+      const [hoursStr, minutesStr] = timeStr.split(":");
+      let hours = parseInt(hoursStr, 10);
+      const suffix = hours >= 12 ? "PM" : "AM";
+      hours = hours % 12;
+      hours = hours ? hours : 12;
+      return `${hours}:${minutesStr} ${suffix}`;
+    }
+    return timeStr;
+  };
+
+  const getEventTimeLabel = (event: any) => {
+    const start = formatStringTime(event?.startTime);
+    const end = formatStringTime(event?.endTime);
+
+    // If we don't have explicit times, only derive a time from Date fields
+    // when the Date actually contains a non-midnight time component.
+    const deriveTimeFromDateIfMeaningful = (dateString?: string) => {
+      if (!dateString) return null;
+      const date = new Date(dateString);
+      if (
+        date.getHours() === 0 &&
+        date.getMinutes() === 0 &&
+        date.getSeconds() === 0
+      ) {
+        return null;
+      }
+      return formatEventTime(dateString);
+    };
+
+    const startLabel =
+      start || deriveTimeFromDateIfMeaningful(event?.startDate);
+    const endLabel = end || deriveTimeFromDateIfMeaningful(event?.endDate);
+
+    if (startLabel && endLabel) return `${startLabel} - ${endLabel}`;
+    return startLabel || "";
+  };
+
   const formatBoothDate = (event: any) => {
     // If platform booth has startDate and endDate, show dates
     if (event.startDate && event.endDate) {
@@ -211,7 +252,7 @@ export default function FavoritesPage() {
                   time={
                     isBoothEvent && !event.startDate
                       ? ""
-                      : formatEventTime(event.startDate)
+                      : getEventTimeLabel(event)
                   }
                   location={
                     event.location ||
@@ -225,6 +266,8 @@ export default function FavoritesPage() {
                   description={event.description}
                   startDate={event.startDate}
                   endDate={event.endDate}
+                  dbStartTime={event.startTime}
+                  dbEndTime={event.endTime}
                   durationWeeks={event.durationWeeks}
                   showActions={true}
                   showDetailedView={false}

--- a/client/src/pages/MyEvents.tsx
+++ b/client/src/pages/MyEvents.tsx
@@ -204,6 +204,7 @@ export default function MyEvents() {
                     endDate={event.endDate}
                     durationWeeks={event.durationWeeks}
                     showActions={true}
+                    showShareButton={false}
                     isRegistered={true}
                     hideRegisterButton={
                       userRole === "student" ||

--- a/server/src/features/facilities/facility.service.js
+++ b/server/src/features/facilities/facility.service.js
@@ -33,8 +33,6 @@ class FacilitiesServiceClass {
 
     if (bookingDate < today) throw new Error("Cannot book a past date");
 
-    const formattedDate = this.getLocalDateString(bookingDate);
-
     // Check availability directly
     const existingBooking = await CourtBooking.findOne({
       courtType,

--- a/server/src/features/users/user.service.js
+++ b/server/src/features/users/user.service.js
@@ -284,7 +284,7 @@ class UserService {
         .populate({
           path: "favoriteEvents",
           select:
-            "name description location locationPreference startDate endDate bannerImage status eventType type category durationWeeks attendees attendeesCount application archivedAt", // Added archivedAt
+            "name description location locationPreference startDate endDate startTime endTime bannerImage status eventType type category durationWeeks attendees attendeesCount application archivedAt", // Added archivedAt
           match: {
             deletedAt: null,
             archivedAt: null, // ✅ Exclude archived events


### PR DESCRIPTION
This pull request introduces improvements to how event times are displayed and handled across the application, especially for favorites and event cards. It adds support for explicit event start and end times, enhances the logic for formatting and displaying these times, and gives more control over the visibility of the share button in event cards. There are also minor backend adjustments to ensure these new fields are available in API responses.

**Event Time Handling and Display:**

* Added support for `startTime` and `endTime` fields in the `FavoriteEvent` interface and included them in API population, allowing explicit storage and retrieval of event times. [[1]](diffhunk://#diff-6bd61699d8a9dc3d0b24b5a04da83e32c34c7b1d3ba57e609adbc10adabe5356R11-R12) [[2]](diffhunk://#diff-672c0cfebeaa20bc0233fd8540112f956a1126f1ed573b290ab1041c00a8c9a6L287-R287)
* Improved time formatting logic in the favorites page and event details dialog to display times in 12-hour format and only show derived times from date fields if the time is not midnight. [[1]](diffhunk://#diff-029bb3069f378dadcc328280f50cf8fda6bc491257c6064c923c426428320d72R86-R126) [[2]](diffhunk://#diff-4d00a3f0bbe1224c95a258209966ff0a8bd51848d979625c9dfd65978c7fa568L97-R130)
* Updated the favorites page to use the new time formatting logic and pass the explicit `dbStartTime` and `dbEndTime` to `EventCard`. [[1]](diffhunk://#diff-029bb3069f378dadcc328280f50cf8fda6bc491257c6064c923c426428320d72L214-R255) [[2]](diffhunk://#diff-029bb3069f378dadcc328280f50cf8fda6bc491257c6064c923c426428320d72R269-R270)

**Event Card Enhancements:**

* Added a new `showShareButton` prop to `EventCard`, allowing control over whether the share button is displayed, and updated its default and conditional rendering logic accordingly. [[1]](diffhunk://#diff-d8a4d7a8b5e065f72a04e4c7670a25d9a7a752c1a16f504fbe4f01b26e8430e7R150) [[2]](diffhunk://#diff-d8a4d7a8b5e065f72a04e4c7670a25d9a7a752c1a16f504fbe4f01b26e8430e7R200) [[3]](diffhunk://#diff-d8a4d7a8b5e065f72a04e4c7670a25d9a7a752c1a16f504fbe4f01b26e8430e7L1688-R1690) [[4]](diffhunk://#diff-d8a4d7a8b5e065f72a04e4c7670a25d9a7a752c1a16f504fbe4f01b26e8430e7L1745-R1747)
* Set `showShareButton={false}` for event cards in the "My Events" page, hiding the share button in that context.

**Other Minor Changes:**

* Removed an unused variable in the facilities service related to date formatting for bookings.